### PR TITLE
Add support for node and common js require

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 *.log
+lib/

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ src/
 tests/
 coverage
 karma.conf.js
+gulpfile.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+src/
+tests/
+coverage
+karma.conf.js

--- a/README.md
+++ b/README.md
@@ -8,15 +8,26 @@ $ npm install just-handlebars-helpers --save
 ```
 ## Usage
 
+Browsers:
 ```html
 <!-- Load Handlebars -->
-<script type="text/javascript" src="/node_modules/handlebars/dist/handlebars.min.js"></script>
+<script type="text/javascript" src="/path/to/handlebars/dist/handlebars.min.js"></script>
 <!-- Load the package -->
-<script type="text/javascript" src="/node_modules/just-handlebars-helpers/dist/h.min.js"></script>
+<script type="text/javascript" src="/path/to/just-handlebars-helpers/dist/h.min.js"></script>
 <script type="text/javascript">
     // Register helpers for Handlebars
     H.registerHelpers(Handlebars);
 </script>
+```
+Node:
+```javascript
+// Load Handlebars
+var Handlebars = require('handlebars');
+// Load the package
+var H = require('just-handlebars-helpers');
+
+// Register helpers for Handlebars
+H.registerHelpers(Handlebars);
 ```
 
 ## Testing the helpers
@@ -32,7 +43,7 @@ $ gulp
 $ npm test
 ```
 
-## Inspired by 
+## Inspired by
  * [Swag](https://github.com/elving/swag)
  * [Dashbars](https://github.com/pismute/dashbars)
  * [Assemble](https://github.com/assemble/handlebars-helpers)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 // Build for Browsers
 var gulp = require('gulp');
+var babel = require('gulp-babel');
 var babelify = require('babelify');
 var uglify = require('gulp-uglify');
 var eslint = require('gulp-eslint');
@@ -11,6 +12,7 @@ var source = require('vinyl-source-stream');
 gulp.task('lint', function() {
     return gulp.src([
             '**/*.js',
+            '!lib/**',
             '!dist/**',
             '!coverage/**',
             '!node_modules/**'
@@ -22,11 +24,18 @@ gulp.task('lint', function() {
 
 // Compile ES6
 gulp.task('compile', ['lint'], function() {
-    return browserify({ entries: './src/H.js', debug: true })
+    return browserify({ entries: './src/H.js', standalone: 'H', debug: true })
         .transform(babelify)
         .bundle()
         .pipe(source('h.js'))
         .pipe(gulp.dest('dist'));
+});
+
+// Build for NPM
+gulp.task('just-transpile', function() {
+    gulp.src('src/**/*.js')
+      .pipe(babel())
+      .pipe(gulp.dest('lib'));
 });
 
 // Uglify
@@ -37,7 +46,7 @@ gulp.task('uglify', ['compile'], function() {
         .pipe(gulp.dest('dist'));
 });
 
-gulp.task('default', ['lint', 'compile', 'uglify']);
+gulp.task('default', ['lint', 'compile', 'just-transpile', 'uglify']);
 
 gulp.task('watch', function() {
     gulp.watch('./src/**/*.js', ['default']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,7 +47,3 @@ gulp.task('uglify', ['compile'], function() {
 });
 
 gulp.task('default', ['lint', 'compile', 'just-transpile', 'uglify']);
-
-gulp.task('watch', function() {
-    gulp.watch('./src/**/*.js', ['default']);
-});

--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
-// Note: the ES6 export default would export that H class in 'default' key
-// so we have to use that
+// Note: ES6 export default would export the H class in 'default' key so we have to use that
 module.exports = require('./lib/H.js').default;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
 
 // TODO: Make it available in the Node environment
-
-module.exports = {};
+module.exports = require('./lib/H.js');

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-
-// TODO: Make it available in the Node environment
-module.exports = require('./lib/H.js');
+// Note: the ES6 export default would export that H class in 'default' key
+// so we have to use that
+module.exports = require('./lib/H.js').default;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "browserify-istanbul": "^0.2.1",
     "eslint": "^2.2.0",
     "gulp": "^3.9.1",
+    "gulp-babel": "^6.1.2",
     "gulp-eslint": "^2.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "test": "karma start --single-run --browsers PhantomJS",
-    "prepublish": "gulp"
+    "prepublish": "gulp --silent"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A lightweight package with common helpers for Handlebars",
   "main": "index.js",
   "dependencies": {
-    "handlebars": "^4.*"
+    "handlebars": "^3.*"
   },
   "devDependencies": {
     "babel-eslint": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "watchify": "^3.7.0"
   },
   "scripts": {
-    "test": "karma start --single-run --browsers PhantomJS"
+    "test": "karma start --single-run --browsers PhantomJS",
+    "prepublish": "gulp"
   },
   "repository": {
     "type": "git",

--- a/src/H.js
+++ b/src/H.js
@@ -3,9 +3,11 @@ import * as strings from './helpers/strings';
 import * as conditionals from './helpers/conditionals';
 
 class H {
-    static registerHelpers(handlebars = window.Handlebars) {
+    static registerHelpers(handlebars) {
 
-        if (!handlebars) {
+        if (!handlebars && typeof global.Handlebars !== 'object') {
+            // In case, handlebars is not provided and it's not available
+            // in the global namespace as well throw the error and halt.
             throw new Error('Handlebars not loaded');
         }
 

--- a/src/H.js
+++ b/src/H.js
@@ -21,8 +21,4 @@ class H {
     }
 }
 
-if (typeof window === 'object') {
-    window.H = H;
-}
-
 export default H;


### PR DESCRIPTION
* Add support for both browsers & node
* Add `just-transpile` task to just transpile the code to ES5 in to `lib/`
* Use the `npm prepublish` script to build the package when installed. 
* Add support for Handlebars `>=3.x`
This closes #11 