### PR TITLE
Add sprintf helper

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
     "parser": "babel-eslint",
     "rules": {
-        "strict": 0
+        "strict": 0,
+        "quotes": [2, "single"]
     },
     "parserOptions": {
         "ecmaVersion": 6,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,7 @@
 {
     "parser": "babel-eslint",
     "rules": {
-        "strict": 0,
-        "quotes": [2, "single"]
+        "strict": 0
     },
     "parserOptions": {
         "ecmaVersion": 6,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# HandlebarHelpers
+# Just Handlebars Helpers [![NPM Version][npm-image]][npm-url]
+[npm-image]: https://badge.fury.io/js/just-handlebars-helpers.svg
+[npm-url]: https://www.npmjs.com/package/just-handlebars-helpers
+
 A lightweight package with common helpers for [Handlebars](https://github.com/wycats/handlebars.js)
 
 ## Installation

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,31 @@ var rename = require('gulp-rename');
 var browserify = require('browserify');
 var source = require('vinyl-source-stream');
 
+// TODO: Move this to separate module
+var shimify = (function() {
+    var transformTools = require('browserify-transform-tools');
+
+    var config = {
+        evaluateArguments: true,
+        jsFilesOnly: true
+    };
+        // A flexible shim transform for browserify
+    return transformTools.makeRequireTransform(
+        'shimify', config,
+        function(args, opts, cb) {
+            var shimmedModules = opts.config || {};
+            var moduleName = args[0];
+            var shim = shimmedModules[moduleName];
+
+            if (typeof shim === 'undefined') {
+                return cb();
+            } else {
+                return cb(null, '(' + shim + ')');
+            }
+        }
+    );
+})();
+
 // Lint using eslint
 gulp.task('lint', function() {
     return gulp.src([
@@ -24,8 +49,20 @@ gulp.task('lint', function() {
 
 // Compile ES6
 gulp.task('compile', ['lint'], function() {
-    return browserify({ entries: './src/H.js', standalone: 'H', debug: true })
+
+    var config = {
+        entries: './src/H.js',
+        standalone: 'H',
+        debug: true
+    };
+
+    var shimifyConfig = {
+        'sprintf-js': '{sprintf: window.sprintf, vsprintf: window.vsprintf}',
+    };
+
+    return browserify(config)
         .transform(babelify)
+        .transform(shimify.configure(shimifyConfig))
         .bundle()
         .pipe(source('h.js'))
         .pipe(gulp.dest('dist'));
@@ -34,14 +71,16 @@ gulp.task('compile', ['lint'], function() {
 // Build for NPM
 gulp.task('just-transpile', function() {
     gulp.src('src/**/*.js')
-      .pipe(babel())
-      .pipe(gulp.dest('lib'));
+        .pipe(babel())
+        .pipe(gulp.dest('lib'));
 });
 
 // Uglify
 gulp.task('uglify', ['compile'], function() {
     return gulp.src('dist/h.js')
-        .pipe(rename({suffix: '.min'}))
+        .pipe(rename({
+            suffix: '.min'
+        }))
         .pipe(uglify())
         .pipe(gulp.dest('dist'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,8 @@ var shimify = (function() {
         evaluateArguments: true,
         jsFilesOnly: true
     };
-        // A flexible shim transform for browserify
+
+    // A flexible shim transform for browserify
     return transformTools.makeRequireTransform(
         'shimify', config,
         function(args, opts, cb) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "babelify": "^7.2.0",
     "browserify": "^13.0.0",
     "browserify-istanbul": "^0.2.1",
+    "browserify-transform-tools": "^1.5.3",
     "eslint": "^2.2.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",

--- a/src/H.js
+++ b/src/H.js
@@ -1,8 +1,10 @@
-import * as html from './helpers/html';
-import * as strings from './helpers/strings';
-import * as conditionals from './helpers/conditionals';
+
+import html from './helpers/html';
+import strings from './helpers/strings';
+import conditionals from './helpers/conditionals';
 
 class H {
+
     static registerHelpers(handlebars) {
 
         if (!handlebars && typeof global.Handlebars !== 'object') {

--- a/src/helpers/conditionals.js
+++ b/src/helpers/conditionals.js
@@ -1,169 +1,168 @@
+
 import {isArray} from '../util/utils';
 
-/**
- * Determine whether or not two values are equal (===).
- * Example usage:
- *      {{eq '3' 3}}    => false
- *
- * @param value1
- * @param value2
- * @returns boolean
- */
-function eq(value1, value2) {
-    return (value1 === value2);
-}
+export default {
+    /**
+    * Determine whether or not two values are equal (===).
+    * Example usage:
+    *      {{eq '3' 3}}    => false
+    *
+    * @param value1
+    * @param value2
+    * @returns boolean
+    */
+    eq: function (value1, value2) {
+        return (value1 === value2);
+    },
 
-/**
- * Determine whether or not two values are equal (==) i.e weak checking.
- * Example usage:
- *      {{eqw '3' 3}}   => true
- *
- * @param value1
- * @param value2
- * @returns boolean
- */
-function eqw(value1, value2) {
-    return (value1 == value2);
-}
+    /**
+    * Determine whether or not two values are equal (==) i.e weak checking.
+    * Example usage:
+    *      {{eqw '3' 3}}   => true
+    *
+    * @param value1
+    * @param value2
+    * @returns boolean
+    */
+    eqw: function (value1, value2) {
+        return (value1 == value2);
+    },
 
+    /**
+    * Determine whether or not two values are not equal (!==).
+    * Example usage:
+    *      {{neq 4 3}}    => true
+    *
+    * @param value1
+    * @param value2
+    * @returns boolean
+    */
+    neq: function (value1, value2) {
+        return (value1 !== value2);
+    },
 
-/**
- * Determine whether or not two values are not equal (!==).
- * Example usage:
- *      {{neq 4 3}}    => true
- *
- * @param value1
- * @param value2
- * @returns boolean
- */
-function neq(value1, value2) {
-    return (value1 !== value2);
-}
+    /**
+    * Determine whether or not two values are not equal (!=) weak checking.
+    * Example usage:
+    *      {{neq '3' 3}}    => false
+    *
+    * @param value1
+    * @param value2
+    * @returns boolean
+    */
+    neqw: function (value1, value2) {
+        return (value1 != value2);
+    },
 
-/**
- * Determine whether or not two values are not equal (!=) weak checking.
- * Example usage:
- *      {{neq '3' 3}}    => false
- *
- * @param value1
- * @param value2
- * @returns boolean
- */
-function neqw(value1, value2) {
-    return (value1 != value2);
-}
+    /**
+    * Check for less than condition (a < b).
+    * Example usage:
+    *      {{lt 2 3}}   => true
+    *
+    * @param value1
+    * @param value2
+    * @returns boolean
+    */
+    lt: function (value1, value2) {
+        return (value1 < value2);
+    },
 
-/**
- * Check for less than condition (a < b).
- * Example usage:
- *      {{lt 2 3}}   => true
- *
- * @param value1
- * @param value2
- * @returns boolean
- */
-function lt(value1, value2) {
-    return (value1 < value2);
-}
+    /**
+    * Check for less than or equals condition (a <= b).
+    * Example usage:
+    *      {{lte 2 3}}   => true
+    *
+    * @param value1
+    * @param value2
+    * @returns boolean
+    */
+    lte: function (value1, value2) {
+        return (value1 <= value2);
+    },
 
-/**
- * Check for less than or equals condition (a <= b).
- * Example usage:
- *      {{lte 2 3}}   => true
- *
- * @param value1
- * @param value2
- * @returns boolean
- */
-function lte(value1, value2) {
-    return (value1 <= value2);
-}
+    /**
+    * Check for greater than condition (a > b).
+    * Example usage:
+    *      {{gt 2 3}}   => false
+    *
+    * @param value1
+    * @param value2
+    * @returns boolean
+    */
+    gt: function (value1, value2) {
+        return (value1 > value2);
+    },
 
-/**
- * Check for greater than condition (a > b).
- * Example usage:
- *      {{gt 2 3}}   => false
- *
- * @param value1
- * @param value2
- * @returns boolean
- */
-function gt(value1, value2) {
-    return (value1 > value2);
-}
+    /**
+    * Check for greater than or equals condition (a >= b).
+    * Example usage:
+    *      {{gte 3 3}}   => true
+    *
+    * @param value1
+    * @param value2
+    * @returns boolean
+    */
+    gte: function (value1, value2) {
+        return (value1 >= value2);
+    },
 
-/**
- * Check for greater than or equals condition (a >= b).
- * Example usage:
- *      {{gte 3 3}}   => true
- *
- * @param value1
- * @param value2
- * @returns boolean
- */
-function gte(value1, value2) {
-    return (value1 >= value2);
-}
+    /**
+    * Helper to imitate the ternary conditional operator ?:
+    * Example usage:
+    *      {{ifx true 'Foo' 'Bar'}}    => Foo
+    *      {{ifx false 'Foo' 'Bar'}}   => Foo
+    *
+    * @param condition
+    * @param value1
+    * @param value2
+    * @returns value1 | value2
+    */
+    ifx: function (condition, value1, value2) {
+        return !!condition ? value1 :value2;
+    },
 
-/**
- * Helper to imitate the ternary conditional operator ?:
- * Example usage:
- *      {{ifx true 'Foo' 'Bar'}}    => Foo
- *      {{ifx false 'Foo' 'Bar'}}   => Foo
- *
- * @param condition
- * @param value1
- * @param value2
- * @returns value1 | value2
- */
-function ifx(condition, value1, value2) {
-    return !!condition ? value1 :value2;
-}
+    /**
+    * Logical NOT of any expression.
+    * Example usage:
+    *      {{not true}}    => false
+    *      {{not false}}   => true
+    *
+    * @param expression
+    * @returns boolean
+    */
+    not: function (expression) {
+        return !expression;
+    },
 
-/**
- * Logical NOT of any expression.
- * Example usage:
- *      {{not true}}    => false
- *      {{not false}}   => true
- *
- * @param expression
- * @returns boolean
- */
-function not(expression) {
-    return !expression;
-}
+    /**
+    * Check if an array is empty.
+    * Example usage:
+    *      {{empty array}} => true | false
+    *
+    * @param array
+    * @returns boolean
+    */
+    empty: function (array) {
+        if (!isArray(array)) {
+            return true;
+        }
 
-/**
- * Check if an array is empty.
- * Example usage:
- *      {{empty array}} => true | false
- *
- * @param array
- * @returns boolean
- */
-function empty(array) {
-    if (!isArray(array)) {
-        return true;
+        return (array.length === 0);
+    },
+
+    /**
+    * Determine the length of an array.
+    * Example usage:
+    *      {{count array}} =>  false | array.length
+    *
+    * @param array
+    * @returns boolean | number
+    */
+    count: function (array) {
+        if (!isArray(array)) {
+            return false;
+        }
+
+        return array.length;
     }
-
-    return (array.length === 0);
-}
-
-/**
- * Determine the length of an array.
- * Example usage:
- *      {{count array}} =>  false | array.length
- *
- * @param array
- * @returns boolean | number
- */
-function count(array) {
-    if (!isArray(array)) {
-        return false;
-    }
-
-    return array.length;
-}
-
-/* Export */
-export {eq, eqw, neq, neqw, lt, lte, gt, gte, ifx, not, empty, count}
+};

--- a/src/helpers/conditionals.js
+++ b/src/helpers/conditionals.js
@@ -2,6 +2,7 @@
 import {isArray} from '../util/utils';
 
 export default {
+
     /**
     * Determine whether or not two values are equal (===).
     * Example usage:
@@ -11,7 +12,7 @@ export default {
     * @param value2
     * @returns boolean
     */
-    eq: function (value1, value2) {
+    eq: (value1, value2) => {
         return (value1 === value2);
     },
 
@@ -24,7 +25,7 @@ export default {
     * @param value2
     * @returns boolean
     */
-    eqw: function (value1, value2) {
+    eqw: (value1, value2) => {
         return (value1 == value2);
     },
 
@@ -37,7 +38,7 @@ export default {
     * @param value2
     * @returns boolean
     */
-    neq: function (value1, value2) {
+    neq: (value1, value2) => {
         return (value1 !== value2);
     },
 
@@ -50,7 +51,7 @@ export default {
     * @param value2
     * @returns boolean
     */
-    neqw: function (value1, value2) {
+    neqw: (value1, value2) => {
         return (value1 != value2);
     },
 
@@ -63,7 +64,7 @@ export default {
     * @param value2
     * @returns boolean
     */
-    lt: function (value1, value2) {
+    lt: (value1, value2) => {
         return (value1 < value2);
     },
 
@@ -76,7 +77,7 @@ export default {
     * @param value2
     * @returns boolean
     */
-    lte: function (value1, value2) {
+    lte: (value1, value2) => {
         return (value1 <= value2);
     },
 
@@ -89,7 +90,7 @@ export default {
     * @param value2
     * @returns boolean
     */
-    gt: function (value1, value2) {
+    gt: (value1, value2) => {
         return (value1 > value2);
     },
 
@@ -102,7 +103,7 @@ export default {
     * @param value2
     * @returns boolean
     */
-    gte: function (value1, value2) {
+    gte: (value1, value2) => {
         return (value1 >= value2);
     },
 
@@ -117,7 +118,7 @@ export default {
     * @param value2
     * @returns value1 | value2
     */
-    ifx: function (condition, value1, value2) {
+    ifx: (condition, value1, value2) => {
         return !!condition ? value1 :value2;
     },
 
@@ -142,7 +143,7 @@ export default {
     * @param array
     * @returns boolean
     */
-    empty: function (array) {
+    empty: (array) => {
         if (!isArray(array)) {
             return true;
         }
@@ -158,7 +159,7 @@ export default {
     * @param array
     * @returns boolean | number
     */
-    count: function (array) {
+    count: (array) => {
         if (!isArray(array)) {
             return false;
         }

--- a/src/helpers/html.js
+++ b/src/helpers/html.js
@@ -1,50 +1,51 @@
-/**
- * A showIf helper for showing any html element.
- * Example usage:
- *      {{showIf true}} => ''
- *
- * @param expression
- * @returns string
- */
-function showIf(expression) {
-    return !!expression ? '' : 'hidden';
-}
 
-/**
- * A hideIf helper for hiding any html element.
- * Example usage:
- *      {{hideIf true}} => 'hidden'
- *
- * @param expression
- * @returns string
- */
-function hideIf(expression) {
-    return !!expression ? 'hidden' : '';
-}
+export default {
+    /**
+     * A showIf helper for showing any html element.
+     * Example usage:
+     *      {{showIf true}} => ''
+     *
+     * @param expression
+     * @returns string
+     */
+    showIf: function(expression) {
+        return !!expression ? '' : 'hidden';
+    },
 
-/**
- * A selectedIf helper for dropdown and radio boxes.
- * Example usage:
- *      {{selectedIf true}} =>  'selected'
- *
- * @param expression
- * @returns string
- */
-function selectedIf(expression) {
-    return !!expression ? 'selected' : '';
-}
+    /**
+     * A hideIf helper for hiding any html element.
+     * Example usage:
+     *      {{hideIf true}} => 'hidden'
+     *
+     * @param expression
+     * @returns string
+     */
+    hideIf: function(expression) {
+        return !!expression ? 'hidden' : '';
+    },
 
-/**
- * A checkedIf helper for checkboxes.
- * Example usage:
- *      {{checkedIf true}}  => 'checked'
- *
- * @param expression
- * @returns string
- */
-function checkedIf(expression) {
-    return !!expression ? 'checked' : '';
-}
+    /**
+     * A selectedIf helper for dropdown and radio boxes.
+     * Example usage:
+     *      {{selectedIf true}} =>  'selected'
+     *
+     * @param expression
+     * @returns string
+     */
+    selectedIf: function(expression) {
+        return !!expression ? 'selected' : '';
+    },
 
-/* Export */
-export {showIf, hideIf, checkedIf, selectedIf};
+    /**
+     * A checkedIf helper for checkboxes.
+     * Example usage:
+     *      {{checkedIf true}}  => 'checked'
+     *
+     * @param expression
+     * @returns string
+     */
+    checkedIf: function(expression) {
+        return !!expression ? 'checked' : '';
+    }
+
+};

--- a/src/helpers/html.js
+++ b/src/helpers/html.js
@@ -8,7 +8,7 @@ export default {
      * @param expression
      * @returns string
      */
-    showIf: function(expression) {
+    showIf: (expression) => {
         return !!expression ? '' : 'hidden';
     },
 
@@ -20,7 +20,7 @@ export default {
      * @param expression
      * @returns string
      */
-    hideIf: function(expression) {
+    hideIf: (expression) => {
         return !!expression ? 'hidden' : '';
     },
 
@@ -32,7 +32,7 @@ export default {
      * @param expression
      * @returns string
      */
-    selectedIf: function(expression) {
+    selectedIf: (expression) => {
         return !!expression ? 'selected' : '';
     },
 
@@ -44,7 +44,7 @@ export default {
      * @param expression
      * @returns string
      */
-    checkedIf: function(expression) {
+    checkedIf: (expression) => {
         return !!expression ? 'checked' : '';
     }
 

--- a/src/helpers/strings.js
+++ b/src/helpers/strings.js
@@ -1,73 +1,81 @@
-/**
- * Extract a few characters from a string. Default number of characters is 50.
- * Example usage:
- *      {{excerpt 'Just Wow' 4}}    => 'Just'
- *
- * @param string
- * @param length
- * @returns string
- */
-function excerpt(string, length) {
-    length = parseInt(length) || 50;
 
-    if (typeof (string) !== 'string' || typeof (length) !== 'number') {
+export default {
+
+    /**
+     * Extract a few characters from a string. Default number of characters is 50.
+     * Example usage:
+     *      {{excerpt 'Just Wow' 4}}    => 'Just'
+     *
+     * @param string
+     * @param length
+     * @returns string
+     */
+    excerpt: function (string, length) {
+        length = parseInt(length) || 50;
+
+        if (typeof (string) !== 'string' || typeof (length) !== 'number') {
+            return string;
+        }
+
+        if (string.length < length) {
+            return string;
+        }
+
+        return string.slice(0, length) + '...';
+    },
+
+    /**
+     * Convert a string to url friendly dash-case string removing special characters.
+     * Example usage:
+     *      {{sanitize 'JuSt #Wow'}}    => 'just-wow'
+     *
+     * @param string
+     * @returns string
+     */
+    sanitize: function (string) {
+        string = string.replace(/[^\w\s]/gi, '').trim();
+
+        return string.replace(/\s+/, '-').toLowerCase();
+    },
+
+    /**
+     * Capitalize each letter of a string.
+     * Example usage:
+     *      {{capitalizeEach 'just wow'}}   => 'Just Wow'
+     *
+     * @param string
+     * @returns string
+     */
+    capitalizeEach: function (string) {
+        if (typeof string === 'string') {
+            return string.toLowerCase().replace(/\w\S*/g, function (match) {
+                return match.charAt(0).toUpperCase() + match.substr(1);
+            });
+        }
+
         return string;
-    }
+    },
 
-    if (string.length < length) {
+    /**
+     * Capitalize the first letter of a string.
+     * Example usage:
+     *      {{capitalizeFirst 'just wow'}}   => 'Just wow'
+     *
+     * @param string
+     * @returns string
+     */
+    capitalizeFirst: function (string) {
+        if (typeof string === 'string') {
+            return string.charAt(0).toUpperCase() + string.slice(1);
+        }
+
         return string;
+    },
+
+    /**
+     *
+     */
+    sprintf: function (format, ...args) {
+        return 'Hello world';
     }
-
-    return string.slice(0, length) + '...';
-}
-
-/**
- * Convert a string to url friendly dash-case string removing special characters.
- * Example usage:
- *      {{sanitize 'JuSt #Wow'}}    => 'just-wow'
- *
- * @param string
- * @returns string
- */
-function sanitize(string) {
-    string = string.replace(/[^\w\s]/gi, '').trim();
-
-    return string.replace(/\s+/, '-').toLowerCase();
-}
-
-/**
- * Capitalize each letter of a string.
- * Example usage:
- *      {{capitalizeEach 'just wow'}}   => 'Just Wow'
- *
- * @param string
- * @returns string
- */
-function capitalizeEach(string) {
-    if (typeof string === 'string') {
-        return string.toLowerCase().replace(/\w\S*/g, function (match) {
-            return match.charAt(0).toUpperCase() + match.substr(1);
-        });
-    }
-
-    return string;
-}
-
-/**
- * Capitalize the first letter of a string.
- * Example usage:
- *      {{capitalizeFirst 'just wow'}}   => 'Just wow'
- *
- * @param string
- * @returns string
- */
-function capitalizeFirst(string) {
-    if (typeof string === 'string') {
-        return string.charAt(0).toUpperCase() + string.slice(1);
-    }
-
-    return string;
-}
-
-/* Export */
-export {excerpt, sanitize, capitalizeEach, capitalizeFirst}
+};

--- a/src/helpers/strings.js
+++ b/src/helpers/strings.js
@@ -98,13 +98,19 @@ export default {
      * @param ...args
      */
     sprintf: (format, ...args) => {
+
+        // Check if the vsprintf function is available globally
+        // if it's not available then try to require() it
         var _vsprintf = global.vsprintf;
 
         if (!isFunction(_vsprintf)) {
             _vsprintf = require('sprintf-js').vsprintf;
         }
 
+        // Normalize all the parameters before passing it to the
+        // sprintf/vsprintf function
         var params = [];
+
         args.forEach(arg => {
             if (isObject(arg) && isObject(arg.hash)) {
                 arg = arg.hash;
@@ -113,6 +119,6 @@ export default {
             params.push(arg);
         });
 
-        return params.length > 0 ? _vsprintf(format, params) : format;
+        return (params.length > 0) ? _vsprintf(format, params) : format;
     }
 };

--- a/src/helpers/strings.js
+++ b/src/helpers/strings.js
@@ -104,7 +104,9 @@ export default {
         var _vsprintf = global.vsprintf;
 
         if (!isFunction(_vsprintf)) {
-            _vsprintf = require('sprintf-js').vsprintf;
+            // Don't let browserify/webpack require that stuff right in here
+            var r = require;
+            _vsprintf = r('sprintf-js').vsprintf;
         }
 
         // Normalize all the parameters before passing it to the

--- a/src/helpers/strings.js
+++ b/src/helpers/strings.js
@@ -104,9 +104,7 @@ export default {
         var _vsprintf = global.vsprintf;
 
         if (!isFunction(_vsprintf)) {
-            // Don't let browserify/webpack require that stuff right in here
-            var r = require;
-            _vsprintf = r('sprintf-js').vsprintf;
+            _vsprintf = require('sprintf-js').vsprintf;
         }
 
         // Normalize all the parameters before passing it to the

--- a/src/helpers/strings.js
+++ b/src/helpers/strings.js
@@ -12,7 +12,7 @@ export default {
      * @param length
      * @returns string
      */
-    excerpt: function(string, length) {
+    excerpt: (string, length) => {
         length = parseInt(length) || 50;
 
         if (typeof(string) !== 'string' || typeof(length) !== 'number') {
@@ -34,7 +34,7 @@ export default {
      * @param string
      * @returns string
      */
-    sanitize: function(string) {
+    sanitize: (string) => {
         string = string.replace(/[^\w\s]/gi, '').trim();
 
         return string.replace(/\s+/, '-').toLowerCase();
@@ -48,7 +48,7 @@ export default {
      * @param string
      * @returns string
      */
-    capitalizeEach: function(string) {
+    capitalizeEach: (string) => {
         if (typeof string === 'string') {
             return string.toLowerCase().replace(/\w\S*/g, function(match) {
                 return match.charAt(0).toUpperCase() + match.substr(1);
@@ -66,7 +66,7 @@ export default {
      * @param string
      * @returns string
      */
-    capitalizeFirst: function(string) {
+    capitalizeFirst: (string) => {
         if (typeof string === 'string') {
             return string.charAt(0).toUpperCase() + string.slice(1);
         }
@@ -97,7 +97,7 @@ export default {
      * @param format
      * @param ...args
      */
-    sprintf: function(format, ...args) {
+    sprintf: (format, ...args) => {
         var _vsprintf = global.vsprintf;
 
         if (!isFunction(_vsprintf)) {

--- a/src/helpers/strings.js
+++ b/src/helpers/strings.js
@@ -1,4 +1,6 @@
 
+import { isFunction, isObject } from '../util/utils';
+
 export default {
 
     /**
@@ -10,10 +12,10 @@ export default {
      * @param length
      * @returns string
      */
-    excerpt: function (string, length) {
+    excerpt: function(string, length) {
         length = parseInt(length) || 50;
 
-        if (typeof (string) !== 'string' || typeof (length) !== 'number') {
+        if (typeof(string) !== 'string' || typeof(length) !== 'number') {
             return string;
         }
 
@@ -32,7 +34,7 @@ export default {
      * @param string
      * @returns string
      */
-    sanitize: function (string) {
+    sanitize: function(string) {
         string = string.replace(/[^\w\s]/gi, '').trim();
 
         return string.replace(/\s+/, '-').toLowerCase();
@@ -46,9 +48,9 @@ export default {
      * @param string
      * @returns string
      */
-    capitalizeEach: function (string) {
+    capitalizeEach: function(string) {
         if (typeof string === 'string') {
-            return string.toLowerCase().replace(/\w\S*/g, function (match) {
+            return string.toLowerCase().replace(/\w\S*/g, function(match) {
                 return match.charAt(0).toUpperCase() + match.substr(1);
             });
         }
@@ -64,7 +66,7 @@ export default {
      * @param string
      * @returns string
      */
-    capitalizeFirst: function (string) {
+    capitalizeFirst: function(string) {
         if (typeof string === 'string') {
             return string.charAt(0).toUpperCase() + string.slice(1);
         }
@@ -73,9 +75,44 @@ export default {
     },
 
     /**
+     * A sprintf helper to be used in the handlebars templates that supports arbitrary parameters.
      *
+     * NOTE: This helper relies on sprintf() function provided by https://github.com/alexei/sprintf.js
+     * So, make sure you have the sprintf-js package available either as a node module
+     * or have sprintf/vsprintf functions available in the global scope from that package.
+     *
+     *  Syntax:
+     *      {{sprintf format arg1 arg2 arg3....}}
+     *      {{sprintf format object}}
+     *      {{sprintf format key1=value1 key2=value2...}}
+     *
+     *  Example usage:
+     *      {{sprintf '%s %s!' 'Hello' 'Kabir' }}
+     *      {{sprintf '%s %s %d %s %d' 'Foo' 'Bar' 55 'Baz' '20'}}
+     *      {{sprintf '%(greeting)s %(name)s! How are you?' obj }}
+     *      {{sprintf '%(greeting)s %(name)s! ' greeting='Hello' name='Kabir'}}
+     *
+     *  Check this https://github.com/alexei/sprintf.js for more information
+     *
+     * @param format
+     * @param ...args
      */
-    sprintf: function (format, ...args) {
-        return 'Hello world';
+    sprintf: function(format, ...args) {
+        var _vsprintf = global.vsprintf;
+
+        if (!isFunction(_vsprintf)) {
+            _vsprintf = require('sprintf-js').vsprintf;
+        }
+
+        var params = [];
+        args.forEach(arg => {
+            if (isObject(arg) && isObject(arg.hash)) {
+                arg = arg.hash;
+            }
+
+            params.push(arg);
+        });
+
+        return params.length > 0 ? _vsprintf(format, params) : format;
     }
 };

--- a/tests/H.spec.js
+++ b/tests/H.spec.js
@@ -1,13 +1,14 @@
+
 import H from '../src/H';
-import handlebars from 'handlebars';
+import Handlebars from 'handlebars';
 
 describe('H.registerHelpers', () => {
 
     it('check if handlebars helpers are registered from each module', () => {
-        H.registerHelpers(handlebars);
-        spyOn(handlebars.helpers, 'ifx');
-        spyOn(handlebars.helpers, 'excerpt');
-        spyOn(handlebars.helpers, 'checkedIf');
+        H.registerHelpers(Handlebars);
+        spyOn(Handlebars.helpers, 'ifx');
+        spyOn(Handlebars.helpers, 'excerpt');
+        spyOn(Handlebars.helpers, 'checkedIf');
     });
-    
+
 });

--- a/tests/helpers/conditionals.spec.js
+++ b/tests/helpers/conditionals.spec.js
@@ -1,4 +1,5 @@
-import * as conditionals from '../../src/helpers/conditionals';
+
+import conditionals from '../../src/helpers/conditionals';
 
 describe('conditionals', () => {
 

--- a/tests/helpers/html.spec.js
+++ b/tests/helpers/html.spec.js
@@ -1,4 +1,5 @@
-import * as html from '../../src/helpers/html';
+
+import html from '../../src/helpers/html';
 
 describe('html', () => {
 

--- a/tests/helpers/strings.spec.js
+++ b/tests/helpers/strings.spec.js
@@ -55,13 +55,11 @@ describe('strings', () => {
 
     /* sprintf */
     it('sprintf function should work as expected (basic support)', () => {
-        // {{sprintf '%(greeting)s %(name)s!' greeting='Hello' name='Kabir' }}
         expect(strings.sprintf('%(greeting)s %(name)s!', {
             hash: { greeting: 'Hello', name: 'Kabir' }
         })).toEqual('Hello Kabir!');
     });
 
-    /* sprintf */
     it('sprintf should work as expected (Basic support)', () => {
         var obj = {
             hash: { greeting: 'Hello', name: 'Kabir' }

--- a/tests/helpers/strings.spec.js
+++ b/tests/helpers/strings.spec.js
@@ -66,31 +66,31 @@ describe('strings', () => {
         var obj = {
             hash: { greeting: 'Hello', name: 'Kabir' }
         };
-        
+
         expect(strings.sprintf('%(greeting)s %(name)s!', obj)).toEqual('Hello Kabir!');
     });
 
     it('sprintf should work as expected after compilation (Basic support)', () => {
-        var template = Handlebars.compile("{{sprintf '%(greeting)s %(name)s!' greeting=greeting name=name }}");
+        var template = Handlebars.compile('{{sprintf "%(greeting)s %(name)s!" greeting=greeting name=name }}');
         var obj = { greeting: 'Hello', name: 'Kabir' };
 
         expect(template(obj)).toEqual('Hello Kabir!');
     });
 
     it('sprintf should work as expected after compilation (C-style sprintf)', () => {
-        var template = Handlebars.compile("{{sprintf '%s %s!' 'Hello' 'Kabir' }}");
+        var template = Handlebars.compile('{{sprintf "%s %s!" "Hello" "Kabir" }}');
 
         expect(template()).toEqual('Hello Kabir!');
     });
 
     it('sprintf should work as expected after compilation (C-style sprintf) with arbitrary number of parameters', () => {
-        var template = Handlebars.compile("{{sprintf 'This is a test: %s %s %d %s %d' 'Foo' 'Bar' 55 'Baz' '20'}}");
+        var template = Handlebars.compile('{{sprintf "This is a test: %s %s %d %s %d" "Foo" "Bar" 55 "Baz" "20"}}');
 
         expect(template()).toEqual('This is a test: Foo Bar 55 Baz 20');
     });
 
     it('sprintf should work as expected after compilation if an object is passed dynamically', () => {
-        var template = Handlebars.compile("{{sprintf '%(greeting)s %(name)s! How are you?' obj }}");
+        var template = Handlebars.compile('{{sprintf "%(greeting)s %(name)s! How are you?" obj }}');
         var obj = { greeting: 'Hello', name: 'Kabir' };
 
         expect(template({obj})).toEqual('Hello Kabir! How are you?');

--- a/tests/helpers/strings.spec.js
+++ b/tests/helpers/strings.spec.js
@@ -1,4 +1,5 @@
 
+import Handlebars from 'handlebars';
 import strings from '../../src/helpers/strings';
 
 describe('strings', () => {
@@ -53,8 +54,48 @@ describe('strings', () => {
     });
 
     /* sprintf */
-    it('sprintf should work as expected', () => {
-        expect(strings.sprintf('Hello %s', 'world')).toEqual('Hello world');
+    it('sprintf function should work as expected (basic support)', () => {
+        // {{sprintf '%(greeting)s %(name)s!' greeting='Hello' name='Kabir' }}
+        expect(strings.sprintf('%(greeting)s %(name)s!', {
+            hash: {
+                greeting: 'Hello',
+                name: 'Kabir'
+            }
+        })).toEqual('Hello Kabir!');
+    });
+
+    /* sprintf */
+    it('sprintf should work as expected (Basic support)', () => {
+        expect(strings.sprintf('%(greeting)s %(name)s!', {
+            hash: { greeting: 'Hello', name: 'Kabir' }
+        })).toEqual('Hello Kabir!');
+    });
+
+    it('sprintf should work as expected after compilation (Basic support)', () => {
+        var template = Handlebars.compile("{{sprintf '%(greeting)s %(name)s!' greeting=greeting name=name }}");
+
+        expect(template(
+            { greeting: 'Hello', name: 'Kabir' }
+        )).toEqual('Hello Kabir!');
+    });
+
+    it('sprintf should work as expected after compilation (C-style sprintf)', () => {
+        var template = Handlebars.compile("{{sprintf '%s %s!' 'Hello' 'Kabir' }}");
+
+        expect(template()).toEqual('Hello Kabir!');
+    });
+
+    it('sprintf should work as expected after compilation (C-style sprintf) with arbitrary number of parameters', () => {
+        var template = Handlebars.compile("{{sprintf 'This is a test: %s %s %d %s %d' 'Foo' 'Bar' 55 'Baz' '20'}}");
+
+        expect(template()).toEqual('This is a test: Foo Bar 55 Baz 20');
+    });
+
+    it('sprintf should work as expected after compilation if an object is passed dynamically', () => {
+        var template = Handlebars.compile("{{sprintf '%(greeting)s %(name)s! How are you?' obj }}");
+        var obj = { greeting: 'Hello', name: 'Kabir' };
+
+        expect(template({obj})).toEqual('Hello Kabir! How are you?');
     });
 
 });

--- a/tests/helpers/strings.spec.js
+++ b/tests/helpers/strings.spec.js
@@ -57,26 +57,24 @@ describe('strings', () => {
     it('sprintf function should work as expected (basic support)', () => {
         // {{sprintf '%(greeting)s %(name)s!' greeting='Hello' name='Kabir' }}
         expect(strings.sprintf('%(greeting)s %(name)s!', {
-            hash: {
-                greeting: 'Hello',
-                name: 'Kabir'
-            }
+            hash: { greeting: 'Hello', name: 'Kabir' }
         })).toEqual('Hello Kabir!');
     });
 
     /* sprintf */
     it('sprintf should work as expected (Basic support)', () => {
-        expect(strings.sprintf('%(greeting)s %(name)s!', {
+        var obj = {
             hash: { greeting: 'Hello', name: 'Kabir' }
-        })).toEqual('Hello Kabir!');
+        };
+        
+        expect(strings.sprintf('%(greeting)s %(name)s!', obj)).toEqual('Hello Kabir!');
     });
 
     it('sprintf should work as expected after compilation (Basic support)', () => {
         var template = Handlebars.compile("{{sprintf '%(greeting)s %(name)s!' greeting=greeting name=name }}");
+        var obj = { greeting: 'Hello', name: 'Kabir' };
 
-        expect(template(
-            { greeting: 'Hello', name: 'Kabir' }
-        )).toEqual('Hello Kabir!');
+        expect(template(obj)).toEqual('Hello Kabir!');
     });
 
     it('sprintf should work as expected after compilation (C-style sprintf)', () => {

--- a/tests/helpers/strings.spec.js
+++ b/tests/helpers/strings.spec.js
@@ -1,4 +1,5 @@
-import * as strings from '../../src/helpers/strings';
+
+import strings from '../../src/helpers/strings';
 
 describe('strings', () => {
 
@@ -49,6 +50,11 @@ describe('strings', () => {
 
     it('capitalizeEach should return the param if it is not a string', () => {
         expect(strings.capitalizeEach(1)).toEqual(1);
+    });
+
+    /* sprintf */
+    it('sprintf should work as expected', () => {
+        expect(strings.sprintf('Hello %s', 'world')).toEqual('Hello world');
     });
 
 });


### PR DESCRIPTION
Closes issue #9 but **merge PR https://github.com/leapfrogtechnology/just-handlebars-helpers/pull/14 before you look into this one**
* Add `sprintf` helper with lots of features provided by [sprintf-js](https://www.npmjs.com/package/sprintf-js) package but not adding it as a hard dependency. The users would need to have that in their package **only if** they use this helper. 
* So, these things are all possible now: 

  ```html
  {{sprintf '%s %s!' 'Hello' 'Kabir' }}
  {{sprintf '%s %s %d %s %d' 'Foo' 'Bar' 55 'Baz' '20'}}
  {{sprintf '%(greeting)s %(name)s!' object }}
  {{sprintf '%(greeting)s %(name)s! ' greeting='Hello' name='Kabir'}}
   ```
* Refactor and have a shorthand, less-verbose and more readable syntax for writing helpers
* Added a custom browserify transform shim to replace all `require()` stuffs in the dist with corresponding global variable in browsers
* And, add npm version badge: [![npm version](https://badge.fury.io/js/just-handlebars-helpers.svg)](https://badge.fury.io/js/just-handlebars-helpers) in the README