### PR TITLE
Refactor specs

### DIFF
--- a/tests/helpers/conditionals.spec.js
+++ b/tests/helpers/conditionals.spec.js
@@ -3,139 +3,150 @@ import conditionals from '../../src/helpers/conditionals';
 
 describe('conditionals', () => {
 
-    /* eq */
-    it('eq should return true if provided params are equal and are of same type', () => {
-        expect(conditionals.eq('1', '1')).toEqual(true);
+    describe('eq', () => {
+        it('should return true if provided params are equal and are of same type', () => {
+            expect(conditionals.eq('1', '1')).toEqual(true);
+        });
+
+        it('should return false if provided params are equal but not of same type', () => {
+            expect(conditionals.eq('1', 1)).toEqual(false);
+        });
     });
 
-    it('eq should return false if provided params are equal but not of same type', () => {
-        expect(conditionals.eq('1', 1)).toEqual(false);
+    describe('eqw', () => {
+        it('should return true if provided params are equal and are of same type', () => {
+            expect(conditionals.eqw('1', '1')).toEqual(true);
+        });
+
+        it('should also return true if provided params are equal but not of same type', () => {
+            expect(conditionals.eqw('1', 1)).toEqual(true);
+        });
     });
 
-    /* eqw */
-    it('eqw should return true if provided params are equal and are of same type', () => {
-        expect(conditionals.eqw('1', '1')).toEqual(true);
+    describe('neq', () => {
+        it('should return true if provided params are not equal', () => {
+            expect(conditionals.neq(4, 3)).toEqual(true);
+        });
+
+        it('should return false if provided params are equal and of same type', () => {
+            expect(conditionals.neq(3, 3)).toEqual(false);
+        });
+
+        it('should return true if provided params are equal but of different types', () => {
+            expect(conditionals.neq('3', 3)).toEqual(true);
+        });
     });
 
-    it('eq should also return true if provided params are equal but not of same type', () => {
-        expect(conditionals.eqw('1', 1)).toEqual(true);
+    describe('neqw', () => {
+        it('should return true if provided params are not equal', () => {
+            expect(conditionals.neqw(4, 3)).toEqual(true);
+        });
+
+        it('should return false if provided params are equal and of same type', () => {
+            expect(conditionals.neqw(3, 3)).toEqual(false);
+        });
+
+        it('should return false if provided params are equal but of different types', () => {
+            expect(conditionals.neqw('3', 3)).toEqual(false);
+        });
     });
 
-    /* neq */
-    it('neq should return true if provided params are not equal', () => {
-        expect(conditionals.neq(4, 3)).toEqual(true);
+    describe('lt', () => {
+        it('should return true if param1 is smaller than param2', () => {
+            expect(conditionals.lt(1, 2)).toEqual(true);
+        });
+
+        it('should return false if param1 is equal to param2', () => {
+            expect(conditionals.lt(1, 1)).toEqual(false);
+        });
+
+        it('should return false if param2 is smaller than param1', () => {
+            expect(conditionals.lt('31', '11')).toEqual(false); // Lexicographical Order
+        });
     });
 
-    it('neq should return false if provided params are equal and of same type', () => {
-        expect(conditionals.neq(3, 3)).toEqual(false);
+    describe('lte', () => {
+        it('should return true if param1 is smaller than param2', () => {
+            expect(conditionals.lte(1, 2)).toEqual(true);
+        });
+
+        it('should return true if param1 is equal to param2', () => {
+            expect(conditionals.lte(1, 1)).toEqual(true);
+        });
+
+        it('should return false if param2 is smaller than param1', () => {
+            expect(conditionals.lte(2, 1)).toEqual(false);
+        });
     });
 
-    it('neq should return true if provided params are equal but of different types', () => {
-        expect(conditionals.neq('3', 3)).toEqual(true);
+    describe('gt', () => {
+        it('should return true if param1 is greater than param2', () => {
+            expect(conditionals.gt(2, 1)).toEqual(true);
+        });
+
+        it('should return false if param1 is equal to param2', () => {
+            expect(conditionals.gt(1, 1)).toEqual(false);
+        });
+
+        it('should return false if param2 is greater than param1', () => {
+            expect(conditionals.gt('11', '31')).toEqual(false); // Lexicographical Order
+        });
     });
 
-    /* neqw */
-    it('neqw should return true if provided params are not equal', () => {
-        expect(conditionals.neqw(4, 3)).toEqual(true);
+
+    describe('gte', () => {
+        it('should return true if param1 is greater than param2', () => {
+            expect(conditionals.gte(2, 1)).toEqual(true);
+        });
+
+        it('should return true if param1 is equal to param2', () => {
+            expect(conditionals.gte(1, 1)).toEqual(true);
+        });
+
+        it('should return false if param2 is greater than param1', () => {
+            expect(conditionals.gte(1, 2)).toEqual(false); // Lexicographical Order
+        });
     });
 
-    it('neqw should return false if provided params are equal and of same type', () => {
-        expect(conditionals.neqw(3, 3)).toEqual(false);
+    describe('ifx', () => {
+        it('should return value1 if the condition holds true', () => {
+            expect(conditionals.ifx(2 > 1, 'value 1', 'value 2')).toEqual('value 1');
+        });
+
+        it('should return value2 if the condition results to false', () => {
+            expect(conditionals.ifx(2 < 1, 'value 1', 'value 2')).toEqual('value 2');
+        });
     });
 
-    it('neqw should return false if provided params are equal but of different types', () => {
-        expect(conditionals.neqw('3', 3)).toEqual(false);
+    describe('not', () => {
+        it('should return true if false is passed', () => {
+            expect(conditionals.not(false)).toEqual(true);
+        });
+
+        it('should return false if true is passed', () => {
+            expect(conditionals.not(true)).toEqual(false);
+        });
     });
 
-    /* lt */
-    it('lt should return true if param1 is smaller than param2', () => {
-        expect(conditionals.lt(1, 2)).toEqual(true);
+    describe('empty', () => {
+        it('should return true for an empty array', () => {
+            expect(conditionals.empty([])).toEqual(true);
+        });
+
+        it('should return false for a non-empty array', () => {
+            expect(conditionals.empty([5, 6, 7])).toEqual(false);
+        });
     });
 
-    it('lt should return false if param1 is equal to param2', () => {
-        expect(conditionals.lt(1, 1)).toEqual(false);
-    });
+    describe('count', () => {
+        it('should return the length of an array', () => {
+            expect(conditionals.count([5, 6, 9])).toEqual(3);
+        });
 
-    it('lt should return false if param2 is smaller than param1', () => {
-        expect(conditionals.lt('31', '11')).toEqual(false); // Lexicographical Order
+        it('should return false if param is not an array', () => {
+            expect(conditionals.count({
+                foo: 'bar'
+            })).toEqual(false);
+        });
     });
-
-    /* lte */
-    it('lte should return true if param1 is smaller than param2', () => {
-        expect(conditionals.lte(1, 2)).toEqual(true);
-    });
-
-    it('lte should return true if param1 is equal to param2', () => {
-        expect(conditionals.lte(1, 1)).toEqual(true);
-    });
-
-    it('lte should return false if param2 is smaller than param1', () => {
-        expect(conditionals.lte(2, 1)).toEqual(false);
-    });
-
-    /* gt */
-    it('gt should return true if param1 is greater than param2', () => {
-        expect(conditionals.gt(2, 1)).toEqual(true);
-    });
-
-    it('gt should return false if param1 is equal to param2', () => {
-        expect(conditionals.gt(1, 1)).toEqual(false);
-    });
-
-    it('gt should return false if param2 is greater than param1', () => {
-        expect(conditionals.gt('11', '31')).toEqual(false); // Lexicographical Order
-    });
-
-    /* gte */
-    it('gte should return true if param1 is greater than param2', () => {
-        expect(conditionals.gte(2, 1)).toEqual(true);
-    });
-
-    it('gte should return true if param1 is equal to param2', () => {
-        expect(conditionals.gte(1, 1)).toEqual(true);
-    });
-
-    it('gte should return false if param2 is greater than param1', () => {
-        expect(conditionals.gte(1, 2)).toEqual(false); // Lexicographical Order
-    });
-
-    /* ifx */
-    it('ifx should return value1 if the condition holds true', () => {
-        expect(conditionals.ifx(2 > 1, 'value 1', 'value 2')).toEqual('value 1');
-    });
-
-    it('ifx should return value2 if the condition results to false', () => {
-        expect(conditionals.ifx(2 < 1, 'value 1', 'value 2')).toEqual('value 2');
-    });
-
-    /* not */
-    it('not should return true if false is passed', () => {
-        expect(conditionals.not(false)).toEqual(true);
-    });
-
-    it('not should return false if true is passed', () => {
-        expect(conditionals.not(true)).toEqual(false);
-    });
-
-    /* empty */
-    it('empty should return true for an empty array', () => {
-        expect(conditionals.empty([])).toEqual(true);
-    });
-
-    it('empty should return false for a non-empty array', () => {
-        expect(conditionals.empty([5, 6, 7])).toEqual(false);
-    });
-
-    /* count */
-    it('count should return the length of an array', () => {
-        expect(conditionals.count([5, 6, 9])).toEqual(3);
-    });
-
-    /* count */
-    it('count should return false if param is not an array', () => {
-        expect(conditionals.count({
-            foo: 'bar'
-        })).toEqual(false);
-    });
-
 });

--- a/tests/helpers/html.spec.js
+++ b/tests/helpers/html.spec.js
@@ -3,56 +3,59 @@ import html from '../../src/helpers/html';
 
 describe('html', () => {
 
-    /* showIf */
-    it('showIf should return empty if param is false', () => {
-        expect(html.showIf(false)).toEqual('hidden');
+    describe('showIf', () => {
+        it('should return empty if param is false', () => {
+            expect(html.showIf(false)).toEqual('hidden');
+        });
+
+        it('should return hidden if param is true', () => {
+            expect(html.showIf(true)).toEqual('');
+        });
+
+        it('should return empty for a random param', () => {
+            expect(html.showIf('random')).toEqual('');
+        });
     });
 
-    it('showIf should return hidden if param is true', () => {
-        expect(html.showIf(true)).toEqual('');
+    describe('hideIf', () => {
+        it('should return empty if param is false', () => {
+            expect(html.hideIf(false)).toEqual('');
+        });
+
+        it('should return hidden if param is true', () => {
+            expect(html.hideIf(true)).toEqual('hidden');
+        });
+
+        it('should return hidden for a random param', () => {
+            expect(html.hideIf('random')).toEqual('hidden');
+        });
     });
 
-    it('showIf should return empty for a random param', () => {
-        expect(html.showIf('random')).toEqual('');
+    describe('selectedIf', () => {
+        it('should return empty if param is false', () => {
+            expect(html.selectedIf(false)).toEqual('');
+        });
+
+        it('should return hidden if param is true', () => {
+            expect(html.selectedIf(true)).toEqual('selected');
+        });
+
+        it('should return empty for a random param', () => {
+            expect(html.selectedIf('random')).toEqual('selected');
+        });
     });
 
-    /* hideIf */
-    it('hideIf should return empty if param is false', () => {
-        expect(html.hideIf(false)).toEqual('');
-    });
+    describe('checkedIf', () => {
+        it('should return empty if param is false', () => {
+            expect(html.checkedIf(false)).toEqual('');
+        });
 
-    it('hideIf should return hidden if param is true', () => {
-        expect(html.hideIf(true)).toEqual('hidden');
-    });
+        it('should return hidden if param is true', () => {
+            expect(html.checkedIf(true)).toEqual('checked');
+        });
 
-    it('hideIf should return hidden for a random param', () => {
-        expect(html.hideIf('random')).toEqual('hidden');
+        it('should return empty for a random param', () => {
+            expect(html.checkedIf('random')).toEqual('checked');
+        });
     });
-
-    /* selectedIf */
-    it('selectedIf should return empty if param is false', () => {
-        expect(html.selectedIf(false)).toEqual('');
-    });
-
-    it('selectedIf should return hidden if param is true', () => {
-        expect(html.selectedIf(true)).toEqual('selected');
-    });
-
-    it('selectedIf should return empty for a random param', () => {
-        expect(html.selectedIf('random')).toEqual('selected');
-    });
-
-    /* checkedIf */
-    it('checkedIf should return empty if param is false', () => {
-        expect(html.checkedIf(false)).toEqual('');
-    });
-
-    it('checkedIf should return hidden if param is true', () => {
-        expect(html.checkedIf(true)).toEqual('checked');
-    });
-
-    it('checkedIf should return empty for a random param', () => {
-        expect(html.checkedIf('random')).toEqual('checked');
-    });
-
 });

--- a/tests/helpers/math.spec.js
+++ b/tests/helpers/math.spec.js
@@ -1,62 +1,78 @@
-import {compile} from 'handlebars';
+
+import { compile } from 'handlebars';
 import math from '../../src/helpers/math';
 
 describe('math', () => {
 
-    /* sum */
-    it('sum should return the sum of two passed values', () => {
-        expect(math.sum(5, 6)).toEqual(11);
+    describe('sum', () => {
+        it('should return the sum of two passed values', () => {
+            expect(math.sum(5, 6)).toEqual(11);
+        });
+
+        it('helper should return the sum of two passed values', () => {
+            let template = compile('{{sum value 5}}');
+
+            expect(template({
+                value: 6
+            })).toEqual('11');
+        });
+
+        it('helper should also work with floats', () => {
+            let template = compile('{{sum value 5.1}}');
+
+            expect(template({
+                value: 6.7
+            })).toEqual('11.8');
+        });
     });
 
-    it('sum helper should return the sum of two passed values', () => {
-        let template = compile('{{sum value 5}}');
+    describe('difference', () => {
+        it('should return the difference of two passed values', () => {
+            expect(math.difference(5, 6)).toEqual(-1);
+        });
 
-        expect(template({value: 6})).toEqual('11');
+        it('helper should return the difference of two passed values', () => {
+            let template = compile('{{difference value 5}}');
+
+            expect(template({
+                value: 6
+            })).toEqual('1');
+        });
+
+        it('helper should also work with floats', () => {
+            let template = compile('{{difference value 1.2}}');
+
+            expect(template({
+                value: 6.5
+            })).toEqual('5.3');
+        });
     });
 
-    it('sum helper should also work with floats', () => {
-        let template = compile('{{sum value 5.1}}');
+    describe('ceil', () => {
+        it('should return the ceil value of a float number', () => {
+            expect(math.ceil(5.666)).toEqual(6);
+        });
 
-        expect(template({value: 6.7})).toEqual('11.8');
+        it('helper should also return the ceil value of a float number', () => {
+            let template = compile('{{ceil value}}');
+
+            expect(template({
+                value: '5.666'
+            })).toEqual('6');
+        });
     });
 
-    /* difference */
-    it('difference should return the difference of two passed values', () => {
-        expect(math.difference(5, 6)).toEqual(-1);
+    describe('floor', () => {
+        it('should return the floor value of a float number', () => {
+            expect(math.floor(5.666)).toEqual(5);
+        });
+
+        it('helper should also return the floor value of a float number', () => {
+            let template = compile('{{floor value}}');
+
+            expect(template({
+                value: '5.666'
+            })).toEqual('5');
+        });
     });
-
-    it('difference helper should return the difference of two passed values', () => {
-        let template = compile('{{difference value 5}}');
-
-        expect(template({value: 6})).toEqual('1');
-    });
-
-    it('difference helper should also work with floats', () => {
-        let template = compile('{{difference value 1.2}}');
-
-        expect(template({value: 6.5})).toEqual('5.3');
-    });
-
-    /* ceil */
-    it('ceil should return the ceil value of a float number', () => {
-        expect(math.ceil(5.666)).toEqual(6);
-    });
-
-    it('ceil helper should also return the ceil value of a float number', () => {
-        let template = compile('{{ceil value}}');
-
-        expect(template({value: '5.666'})).toEqual('6');
-    });
-
-    /* floor */
-    it('floor should return the floor value of a float number', () => {
-        expect(math.floor(5.666)).toEqual(5);
-    });
-
-    it('floor helper should also return the floor value of a float number', () => {
-        let template = compile('{{floor value}}');
-
-        expect(template({value: '5.666'})).toEqual('5');
-    });
-
 });

--- a/tests/helpers/strings.spec.js
+++ b/tests/helpers/strings.spec.js
@@ -1,97 +1,115 @@
 
-import Handlebars from 'handlebars';
+import {compile} from 'handlebars';
 import strings from '../../src/helpers/strings';
 
 describe('strings', () => {
 
-    /* excerpt */
-    it('excerpt should extract all the characters from a string if it is less than 50 characters by default', () => {
-        expect(strings.excerpt('just wow')).toEqual('just wow');
+    describe('excerpt', () => {
+        it('should extract all the characters from a string if it is less than 50 characters by default', () => {
+            expect(strings.excerpt('just wow')).toEqual('just wow');
+        });
+
+        it('should extract 50 characters from a string if it has more than 50 characters by default', () => {
+            expect(strings.excerpt('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'))
+                .toEqual('Lorem ipsum dolor sit amet, consectetur adipisicin...');
+        });
+
+        it('should extract provided number of characters from a string', () => {
+            expect(strings.excerpt('Just wow', 4)).toEqual('Just...');
+        });
+
+        it('should extract all the characters from a string if the provided number of characters to be extracted is more than the number of characters', () => {
+            expect(strings.excerpt('wow', 10)).toEqual('wow');
+        });
+
+        it('should return the string if the length parameter is not a number', () => {
+            expect(strings.excerpt('just wow', 'random')).toEqual('just wow');
+        });
     });
 
-    it('excerpt should extract 50 characters from a string if it has more than 50 characters by default', () => {
-        expect(strings.excerpt('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'))
-            .toEqual('Lorem ipsum dolor sit amet, consectetur adipisicin...');
+    describe('sanitize', () => {
+        it('should return a normal string as dash case', () => {
+            expect(strings.sanitize('Just    wow')).toEqual('just-wow');
+        });
+
+        it('should return a string with special characters as dash case without special characters', () => {
+            expect(strings.sanitize('*JuST *#wow#')).toEqual('just-wow');
+        });
     });
 
-    it('excerpt should extract provided number of characters from a string', () => {
-        expect(strings.excerpt('Just wow', 4)).toEqual('Just...');
+    describe('capitalizeFirst', () => {
+        it('should capitalize the first letter of a string', () => {
+            expect(strings.capitalizeFirst('just wow')).toEqual('Just wow');
+        });
+
+        it('should return the param if it is not a string', () => {
+            expect(strings.capitalizeFirst(1.1)).toEqual(1.1);
+        });
     });
 
-    it('excerpt should extract all the characters from a string if the provided number of characters to be extracted is more than the number of characters', () => {
-        expect(strings.excerpt('wow', 10)).toEqual('wow');
+    describe('capitalizeEach', () => {
+        it('should capitalize the first letter of a string', () => {
+            expect(strings.capitalizeEach('just wow')).toEqual('Just Wow');
+        });
+
+        it('should return the param if it is not a string', () => {
+            expect(strings.capitalizeEach(1)).toEqual(1);
+        });
     });
 
-    it('excerpt should return the string if the length parameter is not a number', () => {
-        expect(strings.excerpt('just wow', 'random')).toEqual('just wow');
+    describe('sprintf', () => {
+        it('function should work as expected (basic support)', () => {
+            expect(strings.sprintf('%(greeting)s %(name)s!', {
+                hash: {
+                    greeting: 'Hello',
+                    name: 'Kabir'
+                }
+            })).toEqual('Hello Kabir!');
+        });
+
+        it('should work as expected (Basic support)', () => {
+            var obj = {
+                hash: {
+                    greeting: 'Hello',
+                    name: 'Kabir'
+                }
+            };
+
+            expect(strings.sprintf('%(greeting)s %(name)s!', obj)).toEqual('Hello Kabir!');
+        });
+
+        it('should work as expected after compilation (Basic support)', () => {
+            var template = compile('{{sprintf "%(greeting)s %(name)s!" greeting=greeting name=name }}');
+            var obj = {
+                greeting: 'Hello',
+                name: 'Kabir'
+            };
+
+            expect(template(obj)).toEqual('Hello Kabir!');
+        });
+
+        it('should work as expected after compilation (C-style sprintf)', () => {
+            var template = compile('{{sprintf "%s %s!" "Hello" "Kabir" }}');
+
+            expect(template()).toEqual('Hello Kabir!');
+        });
+
+        it('should work as expected after compilation (C-style sprintf) with arbitrary number of parameters', () => {
+            var template = compile('{{sprintf "This is a test: %s %s %d %s %d" "Foo" "Bar" 55 "Baz" "20"}}');
+
+            expect(template()).toEqual('This is a test: Foo Bar 55 Baz 20');
+        });
+
+        it('should work as expected after compilation if an object is passed dynamically', () => {
+            var template = compile('{{sprintf "%(greeting)s %(name)s! How are you?" obj }}');
+            var obj = {
+                greeting: 'Hello',
+                name: 'Kabir'
+            };
+
+            expect(template({
+                obj
+            })).toEqual('Hello Kabir! How are you?');
+        });
     });
-
-    /* sanitize */
-    it('sanitize should return a normal string as dash case', () => {
-        expect(strings.sanitize('Just    wow')).toEqual('just-wow');
-    });
-
-    it('sanitize should return a string with special characters as dash case without special characters', () => {
-        expect(strings.sanitize('*JuST *#wow#')).toEqual('just-wow');
-    });
-
-    /* capitalizeFirst */
-    it('capitalizeFirst should capitalize the first letter of a string', () => {
-        expect(strings.capitalizeFirst('just wow')).toEqual('Just wow');
-    });
-
-    it('capitalizeFirst should return the param if it is not a string', () => {
-        expect(strings.capitalizeFirst(1.1)).toEqual(1.1);
-    });
-
-    /* capitalizeEach */
-    it('capitalizeEach should capitalize the first letter of a string', () => {
-        expect(strings.capitalizeEach('just wow')).toEqual('Just Wow');
-    });
-
-    it('capitalizeEach should return the param if it is not a string', () => {
-        expect(strings.capitalizeEach(1)).toEqual(1);
-    });
-
-    /* sprintf */
-    it('sprintf function should work as expected (basic support)', () => {
-        expect(strings.sprintf('%(greeting)s %(name)s!', {
-            hash: { greeting: 'Hello', name: 'Kabir' }
-        })).toEqual('Hello Kabir!');
-    });
-
-    it('sprintf should work as expected (Basic support)', () => {
-        var obj = {
-            hash: { greeting: 'Hello', name: 'Kabir' }
-        };
-
-        expect(strings.sprintf('%(greeting)s %(name)s!', obj)).toEqual('Hello Kabir!');
-    });
-
-    it('sprintf should work as expected after compilation (Basic support)', () => {
-        var template = Handlebars.compile('{{sprintf "%(greeting)s %(name)s!" greeting=greeting name=name }}');
-        var obj = { greeting: 'Hello', name: 'Kabir' };
-
-        expect(template(obj)).toEqual('Hello Kabir!');
-    });
-
-    it('sprintf should work as expected after compilation (C-style sprintf)', () => {
-        var template = Handlebars.compile('{{sprintf "%s %s!" "Hello" "Kabir" }}');
-
-        expect(template()).toEqual('Hello Kabir!');
-    });
-
-    it('sprintf should work as expected after compilation (C-style sprintf) with arbitrary number of parameters', () => {
-        var template = Handlebars.compile('{{sprintf "This is a test: %s %s %d %s %d" "Foo" "Bar" 55 "Baz" "20"}}');
-
-        expect(template()).toEqual('This is a test: Foo Bar 55 Baz 20');
-    });
-
-    it('sprintf should work as expected after compilation if an object is passed dynamically', () => {
-        var template = Handlebars.compile('{{sprintf "%(greeting)s %(name)s! How are you?" obj }}');
-        var obj = { greeting: 'Hello', name: 'Kabir' };
-
-        expect(template({obj})).toEqual('Hello Kabir! How are you?');
-    });
-
 });

--- a/tests/util/utils.spec.js
+++ b/tests/util/utils.spec.js
@@ -1,53 +1,59 @@
 import * as utils from '../../src/util/utils.js';
 
 describe('utils', () => {
+    describe('isFunction', () => {
+        it('should return true if param is a function', () => {
+            expect(utils.isFunction(parseInt)).toEqual(true);
+        });
 
-    /* isFunction */
-    it('isFunction should return true if param is a function', () => {
-        expect(utils.isFunction(parseInt)).toEqual(true);
+        it('should return false if param is not a function', () => {
+            expect(utils.isFunction(window)).toEqual(false);
+        });
     });
 
-    it('isFunction should return false if param is not a function', () => {
-        expect(utils.isFunction(window)).toEqual(false);
+    describe('isUndefined', () => {
+        it('should return true if param is undefined', () => {
+            expect(utils.isUndefined(undefined)).toEqual(true);
+        });
+
+        it('should return false if param is not undefined', () => {
+            expect(utils.isUndefined('notUndefined')).toEqual(false);
+        });
     });
 
-    /* isUndefined */
-    it('isUndefined should return true if param is undefined', () => {
-        expect(utils.isUndefined(undefined)).toEqual(true);
+    describe('isDefined', () => {
+        it('should return true if param is not undefined', () => {
+            expect(utils.isDefined('notUndefined')).toEqual(true);
+        });
+
+        it('should return false if param is defined', () => {
+            expect(utils.isDefined(undefined)).toEqual(false);
+        });
     });
 
-    it('isUndefined should return false if param is not undefined', () => {
-        expect(utils.isUndefined('notUndefined')).toEqual(false);
+    describe('isObject', () => {
+        it('should return true if param is an object', () => {
+            expect(utils.isObject(window)).toEqual(true);
+        });
+
+        it('should return false if param is not an object', () => {
+            expect(utils.isObject(parseInt)).toEqual(false);
+        });
     });
 
-    /* isDefined */
-    it('isDefined should return true if param is not undefined', () => {
-        expect(utils.isDefined('notUndefined')).toEqual(true);
-    });
+    describe('isArray', () => {
+        it('should return true if param passed is an array', () => {
+            expect(utils.isArray([5, 6, 7])).toEqual(true);
+        });
 
-    it('isDefined should return false if param is defined', () => {
-        expect(utils.isDefined(undefined)).toEqual(false);
-    });
+        it('should return false if param is a normal object', () => {
+            expect(utils.isArray({
+                foo: 'bar'
+            })).toEqual(false);
+        });
 
-    /* isObject */
-    it('isObject should return true if param is an object', () => {
-        expect(utils.isObject(window)).toEqual(true);
-    });
-
-    it('isObject should return false if param is not an object', () => {
-        expect(utils.isObject(parseInt)).toEqual(false);
-    });
-
-    /* isArray */
-    it('isArray should return true if param passed is an array', () => {
-        expect(utils.isArray([5, 6, 7])).toEqual(true);
-    });
-
-    it('isArray should return false if param is a normal object', () => {
-        expect(utils.isArray({foo:'bar'})).toEqual(false);
-    });
-
-    it('isArray should return false if param is a scalar value', () => {
-        expect(utils.isArray(567)).toEqual(false);
+        it('should return false if param is a scalar value', () => {
+            expect(utils.isArray(567)).toEqual(false);
+        });
     });
 });


### PR DESCRIPTION
* Refactor specs
* Now, this is how the tests looks like: 
```
  H.registerHelpers
    ✓ check if handlebars helpers are registered from each module

  conditionals
    eq
      ✓ should return true if provided params are equal and are of same type
      ✓ should return false if provided params are equal but not of same type
    eqw
      ✓ should return true if provided params are equal and are of same type
      ✓ should also return true if provided params are equal but not of same type
    neq
      ✓ should return true if provided params are not equal
      ✓ should return false if provided params are equal and of same type
      ✓ should return true if provided params are equal but of different types
    neqw
      ✓ should return true if provided params are not equal
      ✓ should return false if provided params are equal and of same type
      ✓ should return false if provided params are equal but of different types
    lt
      ✓ should return true if param1 is smaller than param2
      ✓ should return false if param1 is equal to param2
      ✓ should return false if param2 is smaller than param1
    lte
      ✓ should return true if param1 is smaller than param2
      ✓ should return true if param1 is equal to param2
      ✓ should return false if param2 is smaller than param1
    gt
      ✓ should return true if param1 is greater than param2
      ✓ should return false if param1 is equal to param2
      ✓ should return false if param2 is greater than param1
    gte
      ✓ should return true if param1 is greater than param2
      ✓ should return true if param1 is equal to param2
      ✓ should return false if param2 is greater than param1
    ifx
      ✓ should return value1 if the condition holds true
      ✓ should return value2 if the condition results to false
    not
      ✓ should return true if false is passed
      ✓ should return false if true is passed
    empty
      ✓ should return true for an empty array
      ✓ should return false for a non-empty array
    count
      ✓ should return the length of an array
      ✓ should return false if param is not an array

  html
    showIf
      ✓ should return empty if param is false
      ✓ should return hidden if param is true
      ✓ should return empty for a random param
    hideIf
      ✓ should return empty if param is false
      ✓ should return hidden if param is true
      ✓ should return hidden for a random param
    selectedIf
      ✓ should return empty if param is false
      ✓ should return hidden if param is true
      ✓ should return empty for a random param
    checkedIf
      ✓ should return empty if param is false
      ✓ should return hidden if param is true
      ✓ should return empty for a random param

  math
    sum
      ✓ should return the sum of two passed values
      ✓ helper should return the sum of two passed values
      ✓ helper should also work with floats
    difference
      ✓ should return the difference of two passed values
      ✓ helper should return the difference of two passed values
      ✓ helper should also work with floats
    ceil
      ✓ should return the ceil value of a float number
      ✓ helper should also return the ceil value of a float number
    floor
      ✓ should return the floor value of a float number
      ✓ helper should also return the floor value of a float number

  strings
    excerpt
      ✓ should extract all the characters from a string if it is less than 50 characters by default
      ✓ should extract 50 characters from a string if it has more than 50 characters by default
      ✓ should extract provided number of characters from a string
      ✓ should extract all the characters from a string if the provided number of characters to be extracted is more than the number of characters
      ✓ should return the string if the length parameter is not a number
    sanitize
      ✓ should return a normal string as dash case
      ✓ should return a string with special characters as dash case without special characters
    capitalizeFirst
      ✓ should capitalize the first letter of a string
      ✓ should return the param if it is not a string
    capitalizeEach
      ✓ should capitalize the first letter of a string
      ✓ should return the param if it is not a string
    sprintf
      ✓ function should work as expected (basic support)
      ✓ should work as expected (Basic support)
      ✓ should work as expected after compilation (Basic support)
      ✓ should work as expected after compilation (C-style sprintf)
      ✓ should work as expected after compilation (C-style sprintf) with arbitrary number of parameters
      ✓ should work as expected after compilation if an object is passed dynamically

  utils
    isFunction
      ✓ should return true if param is a function
      ✓ should return false if param is not a function
    isUndefined
      ✓ should return true if param is undefined
      ✓ should return false if param is not undefined
    isDefined
      ✓ should return true if param is not undefined
      ✓ should return false if param is defined
    isObject
      ✓ should return true if param is an object
      ✓ should return false if param is not an object
    isArray
      ✓ should return true if param passed is an array
      ✓ should return false if param is a normal object
      ✓ should return false if param is a scalar value

PhantomJS 2.1.1 (Linux 0.0.0): Executed 81 of 81 SUCCESS (0.118 secs / 0.08 secs)
TOTAL: 81 SUCCESS
```

