### PR TITLE
Introduce options helper for <option> lists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6"
   - "5"
   - "4"
   - "0.12"

--- a/README.md
+++ b/README.md
@@ -672,6 +672,66 @@ Usage:
 {{checkedIf true}}  => 'checked'
 ```
 
+### options
+An options helper for generating <option> list for <select> dropdowns.
+
+Common Usages:
+
+```
+{{{options data}}}
+{{{options data selected="value"}}}
+{{{options data id="id" text="description"}}}
+```
+
+A simple example:
+
+```
+let data = [
+    {
+        id: 1,
+        description: 'Foo'
+    },
+    {
+        id: 2,
+        description: 'Bar'
+    },
+    {
+        id: 3,
+        description: 'Foo Bar'
+    }
+];
+```
+```
+{{{options data selected="2"}}}
+```
+will generate html like this:
+```
+<option value="1">Foo</option>
+<option value="2" selected>Bar</option>
+<option value="3">Foo Bar</option>
+```
+You can also override the default key names for `id` & `description` using the `id` & `text` options in the helper.
+```
+let data = [
+    {
+        value: 1,
+        text: 'New York'
+    },
+    {
+        value: 2,
+        text: 'London'
+    }
+];
+```
+```
+{{{options data selected="1" id="value" text="text"}}}
+```
+will generate html like this:
+```
+<option value="1" selected>New York</option>
+<option value="2">London</option>
+```
+
 ## Testing the helpers
 
 ```bash

--- a/src/helpers/conditionals.js
+++ b/src/helpers/conditionals.js
@@ -1,7 +1,6 @@
 import {isArray, isObject} from '../util/utils';
 
 export default {
-
     /**
      * Determine whether or not two values are equal (===).
      * @example

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -1,7 +1,6 @@
 import {isString} from '../util/utils';
 
 export default {
-
     /**
      * A formatDate helper to format date using moment js.
      *

--- a/src/helpers/html.js
+++ b/src/helpers/html.js
@@ -45,6 +45,75 @@ export default {
      */
     checkedIf: (expression) => {
         return !!expression ? 'checked' : '';
+    },
+
+    /**
+     * A options helper for generating <option> list for <select> dropdowns.
+     *
+     * @example
+     * A simple example:
+     *
+     *      let data = [
+     *          {
+     *              id: 1,
+     *              description: 'Foo'
+     *          },
+     *          {
+     *              id: 2,
+     *              description: 'Bar'
+     *          },
+     *          {
+     *              id: 3,
+     *              description: 'Foo Bar'
+     *          }
+     *      ];
+     *
+     *      {{{options data selected="2"}}}
+     *
+     * will generate html like this:
+     *
+     *      <option value="1">Foo</option>
+     *      <option value="2" selected>Bar</option>
+     *      <option value="3">Foo Bar</option>
+     *
+     * @example
+     * You can also override the default key names for 'id' & 'description'
+     * using the 'id' & 'text' options in the helper.
+     *
+     *      let data = [
+     *          {
+     *              value: 1,
+     *              text: 'New York'
+     *          },
+     *          {
+     *              value: 2,
+     *              text: 'London'
+     *          }
+     *      ];
+     *
+     *      {{{options data selected="1" id="value" text="text"}}}
+     *
+     * will generate html like this:
+     *
+     *      <option value="1" selected>New York</option>
+     *      <option value="2">London</option>
+     *
+     */
+    options: (data, opts) => {
+        // The id & text for the <option>
+        let id = opts.hash.id || 'id';
+        let text = opts.hash.text || 'description';
+
+        // The selection "id" of the <option>
+        let selectedId = opts.hash.selected || null;
+
+        return data.map(item => {
+            let value = item[id] || '';
+            let innerText = item[text] || '';
+            let selected = (value == selectedId) ? ' selected': '';
+
+            return `<option value="${value}"${selected}>${innerText}</option>`;
+        }).join('');
     }
 
 };

--- a/src/helpers/html.js
+++ b/src/helpers/html.js
@@ -48,7 +48,7 @@ export default {
     },
 
     /**
-     * A options helper for generating <option> list for <select> dropdowns.
+     * An options helper for generating <option> list for <select> dropdowns.
      *
      * @example
      * A simple example:

--- a/src/helpers/html.js
+++ b/src/helpers/html.js
@@ -113,7 +113,6 @@ export default {
             let selected = (value == selectedId) ? ' selected': '';
 
             return `<option value="${value}"${selected}>${innerText}</option>`;
-        }).join('');
+        }).join('\n');
     }
-
 };

--- a/src/helpers/math.js
+++ b/src/helpers/math.js
@@ -48,5 +48,4 @@ export default {
     floor: (value) => {
         return Math.floor(Number(value));
     }
-
 };

--- a/src/helpers/strings.js
+++ b/src/helpers/strings.js
@@ -1,7 +1,6 @@
 import {isFunction, isObject, isString, isArray} from '../util/utils';
 
 export default {
-
     /**
      * Extract a few characters from a string. Default number of characters is 50.
      * @example

--- a/tests/helpers/html.spec.js
+++ b/tests/helpers/html.spec.js
@@ -15,7 +15,7 @@ describe('html', () => {
         it('should return empty for a random param', () => {
             expect(html.showIf('random')).toEqual('');
         });
-        
+
         it('helper should work as expected after compilation', () => {
             let template = compile('{{showIf boolean}}');
 
@@ -80,6 +80,80 @@ describe('html', () => {
             let template = compile('{{checkedIf boolean}}');
 
             expect(template({boolean: true})).toEqual('checked');
+        });
+    });
+
+    describe('options', () => {
+        it('should return a list of <option> tags according to the data.', () => {
+            let template = compile('{{{options data}}}');
+            let data = [
+                {
+                    id: 1,
+                    description: 'Foo'
+                },
+                {
+                    id: 2,
+                    description: 'Bar'
+                },
+                {
+                    id: 3,
+                    description: 'Foo Bar'
+                }
+            ];
+
+            let html = '<option value="1">Foo</option>' +
+                '<option value="2">Bar</option>' +
+                '<option value="3">Foo Bar</option>';
+
+            expect(template({data})).toEqual(html);
+        });
+
+        it('should return a list of <option> tags along with selected value.', () => {
+            let template = compile('{{{options data selected=sel}}}');
+            let data = [
+                {
+                    id: 1,
+                    description: 'Foo'
+                },
+                {
+                    id: 2,
+                    description: 'Bar'
+                },
+                {
+                    id: 3,
+                    description: 'Foo Bar'
+                }
+            ];
+
+            let html = '<option value="1">Foo</option>' +
+                '<option value="2" selected>Bar</option>' +
+                '<option value="3">Foo Bar</option>';
+
+            expect(template({data, sel: '2'})).toEqual(html);
+        });
+
+        it('should allow overriding the default keys for the options.', () => {
+            let template = compile('{{{options data selected="2" id="key" text="label"}}}');
+            let data = [
+                {
+                    key: 1,
+                    label: 'Foo'
+                },
+                {
+                    key: 2,
+                    label: 'Bar'
+                },
+                {
+                    key: 3,
+                    label: 'Foo Bar'
+                }
+            ];
+
+            let html = '<option value="1">Foo</option>' +
+                '<option value="2" selected>Bar</option>' +
+                '<option value="3">Foo Bar</option>';
+
+            expect(template({data})).toEqual(html);
         });
     });
 });

--- a/tests/helpers/html.spec.js
+++ b/tests/helpers/html.spec.js
@@ -101,9 +101,11 @@ describe('html', () => {
                 }
             ];
 
-            let html = '<option value="1">Foo</option>' +
-                '<option value="2">Bar</option>' +
-                '<option value="3">Foo Bar</option>';
+            let html = [
+                '<option value="1">Foo</option>',
+                '<option value="2">Bar</option>',
+                '<option value="3">Foo Bar</option>'
+            ].join('\n');
 
             expect(template({data})).toEqual(html);
         });
@@ -125,9 +127,11 @@ describe('html', () => {
                 }
             ];
 
-            let html = '<option value="1">Foo</option>' +
-                '<option value="2" selected>Bar</option>' +
-                '<option value="3">Foo Bar</option>';
+            let html = [
+                '<option value="1">Foo</option>',
+                '<option value="2" selected>Bar</option>',
+                '<option value="3">Foo Bar</option>'
+            ].join('\n');
 
             expect(template({data, sel: '2'})).toEqual(html);
         });
@@ -149,9 +153,11 @@ describe('html', () => {
                 }
             ];
 
-            let html = '<option value="1">Foo</option>' +
-                '<option value="2" selected>Bar</option>' +
-                '<option value="3">Foo Bar</option>';
+            let html = [
+                '<option value="1">Foo</option>',
+                '<option value="2" selected>Bar</option>',
+                '<option value="3">Foo Bar</option>'
+            ].join('\n');
 
             expect(template({data})).toEqual(html);
         });


### PR DESCRIPTION
Add a new html helper `{{{options}}}` for generating a list of `<option>` tags for `<select>` dropdowns as this seems to be pretty useful thing. 

This is how it works: 
```
{{{options data}}}
{{{options data selected="value"}}}
{{{options data id="id" text="description"}}} 
```
```
let data = [
    {
        id: 1,
        description: 'Foo'
    },
    {
        id: 2,
        description: 'Bar'
    },
    {
        id: 3,
        description: 'Foo Bar'
    }
];
```
```
{{{options data selected="2"}}}
```
will generate html like this:
```
<option value="1">Foo</option>
<option value="2" selected>Bar</option>
<option value="3">Foo Bar</option>
```
You can also override the default key names for `id` & `description` using the `id` & `text` options in the helper.
```
let data = [
    {
        value: 1,
        text: 'New York'
    },
    {
        value: 2,
        text: 'London'
    }
];
```
```
{{{options data selected="1" id="value" text="text"}}}
```
will generate html like this:
```
<option value="1" selected>New York</option>
<option value="2">London</option>
```