### PR TITLE
Make third parameter of ifx optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ Parameters:
 ```
 condition [boolean] Satisfying condition for getting first value. Either true of false. (Required)
 value1 [mixed] First value to be displayed as result. (Required)
-value2 [mixed] Second value to be displayed as result. (Required)
+value2 [mixed] Second value to be displayed as result. Defaults to an empty string (Optional)
 ```
-Returns `value1 | value2`
+Returns `mixed`
 
 Usage:
 ```
@@ -237,6 +237,10 @@ Usage:
 {{ifx false 'Foo' 'Bar'}}       => Foo  // return (false) ? 'Foo' : 'Bar'
 {{ifx (eq value 1) 5 6}}        => 6    // return (value === 1) ? 5 : 6
 {{ifx (not (eq value 1)) 5 6}}  => 6    // return (value !== 1) ? 5 : 6
+
+<!-- The third parameter is optional, and by default it will be blank string ('') -->
+{{ifx true 'active'}}  => 'active'
+{{ifx false 'active'}}  => ''
 ```
 
 #### empty

--- a/src/helpers/conditionals.js
+++ b/src/helpers/conditionals.js
@@ -107,16 +107,26 @@ export default {
 
     /**
      * Helper to imitate the ternary conditional operator ?:
+     *
      * @example
      *      {{ifx true 'Foo' 'Bar'}}    => Foo
      *      {{ifx false 'Foo' 'Bar'}}   => Foo
      *
      * @param condition
-     * @param value1
-     * @param value2
-     * @returns value1 | value2
+     * @param value1    Value to return when the condition holds true
+     * @param value2    Value to return when the condition is false (Optional)
+     * @returns mixed
      */
     ifx: (condition, value1, value2) => {
+        // Check if user has omitted the last parameter
+        // if that's the case, it would be the handlebars's options object
+        // which it sends always as the last parameter.
+        if (isObject(value2) && value2.name === 'ifx' && value2.hasOwnProperty('hash')) {
+            // This means the user has skipped the last parameter,
+            // so we should return an empty string ('') in the else case instead.
+            value2 = '';
+        }
+
         return !!condition ? value1 : value2;
     },
 
@@ -129,7 +139,7 @@ export default {
      * @param expression
      * @returns boolean
      */
-    not: function (expression) {
+    not: function(expression) {
         return !expression;
     },
 
@@ -244,8 +254,8 @@ export default {
             params.pop();
         }
 
-        for(var i in params) {
-            if(params[i]) {
+        for (var i in params) {
+            if (params[i]) {
                 return params[i];
             }
         }

--- a/tests/helpers/conditionals.spec.js
+++ b/tests/helpers/conditionals.spec.js
@@ -242,6 +242,18 @@ describe('conditionals', () => {
 
             expect(template({value: 2})).toEqual('5');
         });
+
+        it('allows to skip the third parameter', () => {
+            var template = compile('{{ifx isActive "active"}}');
+
+            expect(template({isActive: true})).toEqual('active');
+        });
+
+        it('returns a blank string by default for the false case if third parameter is omitted', () => {
+            var template = compile('{{ifx isActive "active"}}');
+
+            expect(template({isActive: false})).toEqual('');
+        });
     });
 
     describe('not', () => {


### PR DESCRIPTION
* Make the third parameter for `{{ifx}}` optional with a default value empty string (`""`). 
* Closes #34 

So, finally we can write this
```
<li class="{{ifx isActive 'active'}}">
<li class="{{ifx isUnavailable 'unavailable'}}">
```
instead of
```
<li class="{{ifx isActive 'active' ''}}">
<li class="{{ifx isUnavailable 'unavailable' ''}}">
<li class="{{ifx isUnavailable 'unavailable' ''}}">
```

I hope it's more readable and makes better sense. 