### PR TITLE
Add 'includes' helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Can check non-strictly(value only) by sending third argument as false.
 Parameters:
 ```
 params [array] The array. (Required)
-params [mixed] The value to checked for existence in the array. (Required)
+params [mixed] The value to be checked for existence in the array. (Required)
 params [boolean] FALSE for non-strict checking. TRUE by default. (Optional)
 ```
 Returns `boolean`
@@ -356,20 +356,18 @@ Usage:
 var array = [1, 2, 3];
 var value = 2;
 
-{{includes array value}}        => TRUE
+{{includes array value}}        => true
 
-value = '2'
-{{includes array value}}        => FALSE
-{{includes array value true}}   => FALSE
-{{includes array value false}}  => TRUE
-
-// Since it returns a boolean, we can use it in any conditional helpers like:
+var value = '2'
+{{includes array value}}        => false
+{{includes array value true}}   => false
+{{includes array value false}}  => true
 
 {{#if (includes array value)}}
    <!-- Do something -->
 {{/if}}
 
-Includes = {{ifx (includes array value) 'Yes' 'No'}}
+{{ifx (includes array value) 'Yes' 'No'}}
 ```
 
 ### Strings

--- a/README.md
+++ b/README.md
@@ -338,6 +338,40 @@ var fullName = '', nickName = 'foob';
 {{coalesce fullName nickName 'Unknown'}}    => 'foob'
 ```
 
+#### includes
+Returns true if an array includes a value.
+It checks for the existence of the value in array strictly(value + data type) by default.
+Can check non-strictly(value only) by sending third argument as false.
+
+Parameters:
+```
+params [array] The array. (Required)
+params [mixed] The value to checked for existence in the array. (Required)
+params [boolean] FALSE for non-strict checking. TRUE by default. (Optional)
+```
+Returns `boolean`
+
+Usage:
+```
+var array = [1, 2, 3];
+var value = 2;
+
+{{includes array value}}        => TRUE
+
+value = '2'
+{{includes array value}}        => FALSE
+{{includes array value true}}   => FALSE
+{{includes array value false}}  => TRUE
+
+// Since it returns a boolean, we can use it in any conditional helpers like:
+
+{{#if (includes array value)}}
+   <!-- Do something -->
+{{/if}}
+
+Includes = {{ifx (includes array value) 'Yes' 'No'}}
+```
+
 ### Strings
 #### excerpt
 Extract a sub-string from a string.

--- a/src/helpers/conditionals.js
+++ b/src/helpers/conditionals.js
@@ -139,7 +139,7 @@ export default {
      * @param expression
      * @returns boolean
      */
-    not: function(expression) {
+    not: function (expression) {
         return !expression;
     },
 
@@ -261,5 +261,39 @@ export default {
         }
 
         return params.pop();
+    },
+
+    /**
+     * Returns boolean if the array contains the element strictly or non-strictly.
+     * @example
+     *     var array = [1, 2, 3, 4];
+     *     var value1 = 2, value2 = 10, value3 = '3';
+     *     {{includes array value1}}        => true
+     *     {{includes array value2}}        => false
+     *     {{includes array value3}}        => false
+     *     {{includes array value3 false}}  => false
+     *
+     * @param array
+     * @param value
+     * @returns boolean
+     */
+    includes: (array, value, strict = true) => {
+        if (!Array.isArray(array) || array.length === 0) {
+            return false;
+        }
+
+        for (let index in array) {
+            if (strict) {
+                if (array[index] === value) {
+                    return true;
+                }
+            } else {
+                if (array[index] == value) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 };

--- a/src/helpers/conditionals.js
+++ b/src/helpers/conditionals.js
@@ -278,19 +278,13 @@ export default {
      * @returns boolean
      */
     includes: (array, value, strict = true) => {
-        if (!Array.isArray(array) || array.length === 0) {
+        if (!isArray(array) || array.length === 0) {
             return false;
         }
 
         for (let index in array) {
-            if (strict) {
-                if (array[index] === value) {
-                    return true;
-                }
-            } else {
-                if (array[index] == value) {
-                    return true;
-                }
+            if ((strict && array[index] === value) || (!strict && array[index] == value)) {
+                return true;
             }
         }
 

--- a/tests/helpers/conditionals.spec.js
+++ b/tests/helpers/conditionals.spec.js
@@ -177,7 +177,6 @@ describe('conditionals', () => {
         });
     });
 
-
     describe('gte', () => {
         it('should return true if param1 is greater than param2', () => {
             expect(conditionals.gte(2, 1)).toEqual(true);
@@ -407,6 +406,40 @@ describe('conditionals', () => {
             var template = compile('{{coalesce fullName nickName}}');
 
             expect(template({fullName: null, nickName: ''})).toEqual('');
+        });
+    });
+
+    describe('includes', () => {
+        it('should return true if array strictly includes the element after compilation', () => {
+            var value = 3;
+            var array = [1, 2, 3, 4, 5];
+            var template = compile('{{includes array value}}');
+
+            expect(template({array: array, value: value})).toEqual('true');
+        });
+
+        it('should return false if array strictly does not include the element after compilation', () => {
+            var value = '3';
+            var array = [1, 2, 3, 4, 5];
+            var template = compile('{{includes array value}}');
+
+            expect(template({array: array, value: value})).toEqual('false');
+        });
+
+        it('should return true if array non-strictly includes the element after compilation', () => {
+            var value = '3';
+            var array = [1, 2, 3, 4, 5];
+            var template = compile('{{includes array value false}}');
+
+            expect(template({array: array, value: value})).toEqual('true');
+        });
+
+        it('should return false if array non-strictly does not include the element after compilation', () => {
+            var value = '6';
+            var array = [1, 2, 3, 4, 5];
+            var template = compile('{{includes array value false}}');
+
+            expect(template({array: array, value: value})).toEqual('false');
         });
     });
 });

--- a/tests/helpers/conditionals.spec.js
+++ b/tests/helpers/conditionals.spec.js
@@ -441,5 +441,37 @@ describe('conditionals', () => {
 
             expect(template({array: array, value: value})).toEqual('false');
         });
+
+        it('should return false if array argument is not an array', () => {
+            var value = 2;
+            var array = 3;
+            var template = compile('{{includes array value}}');
+
+            expect(template({array: array, value: value})).toEqual('false');
+        });
+
+        it('should return false if array argument is an empty array', () => {
+            var value = 2;
+            var array = [];
+            var template = compile('{{includes array value}}');
+
+            expect(template({array: array, value: value})).toEqual('false');
+        });
+
+        it('should return false if array argument is not an array', () => {
+            var value = 2;
+            var array = 3;
+            var template = compile('{{includes array value}}');
+
+            expect(template({array: array, value: value})).toEqual('false');
+        });
+
+        it('should return false if array checks for existence of an empty string', () => {
+            var value = '';
+            var array = [5, 6, 7];
+            var template = compile('{{includes array value}}');
+
+            expect(template({array: array, value: value})).toEqual('false');
+        });
     });
 });


### PR DESCRIPTION
- Closes #37 
- Add `includes` helper to check for the existence of the value in array strictly(value + data type). 
- Can check non-strictly(value only) by sending third argument as false.
- Checks strictly by default.

Parameters:
```
params [array] The array. (Required)
params [mixed] The value to checked for existence in the array. (Required)
params [boolean] FALSE for non-strict checking. TRUE by default. (Optional)
```
Returns `boolean`

Usage:
```
var array = [1, 2, 3];
var value = 2;

{{includes array value}}        => true

value = '2'
{{includes array value}}        => false
{{includes array value true}}   => false
{{includes array value false}}  => true

// Since it returns a boolean, we can use it in any conditional helpers like:

{{#if (includes array value)}}
   <!-- Do something -->
{{/if}}

{{ifx (includes array value) 'Yes' 'No'}}
```

Test Cases:
```
includes
      ✓ should return true if array strictly includes the element after compilation
      ✓ should return false if array strictly does not include the element after compilation
      ✓ should return true if array non-strictly includes the element after compilation
      ✓ should return false if array non-strictly does not include the element after compilation
      ✓ should return false if array argument is not an array
      ✓ should return false if array argument is an empty array
      ✓ should return false if array argument is not an array
      ✓ should return false if array checks for existence of an empty string
```