### PR TITLE
Fix the Array.prototype issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
   "scripts": {
     "test": "karma start --single-run --browsers PhantomJS",
     "codecov": "cat coverage/*/lcov.info | codecov",
-    "prepublish": "gulp --silent"
+    "start:testing": "karma start",
+    "build": "gulp",
+    "prepublish": "npm run build --silent"
   },
   "repository": {
     "type": "git",

--- a/src/helpers/conditionals.js
+++ b/src/helpers/conditionals.js
@@ -195,8 +195,8 @@ export default {
             params.pop();
         }
 
-        for (var index in params) {
-            if (!params[index]) {
+        for (let i = 0; i < params.length; i++) {
+            if (!params[i]) {
                 return false;
             }
         }
@@ -224,8 +224,8 @@ export default {
             params.pop();
         }
 
-        for (var index in params) {
-            if (params[index]) {
+        for (let i = 0; i < params.length; i++) {
+            if (params[i]) {
                 return true;
             }
         }
@@ -254,7 +254,7 @@ export default {
             params.pop();
         }
 
-        for (var i in params) {
+        for (let i = 0; i < params.length; i++) {
             if (params[i]) {
                 return params[i];
             }
@@ -282,8 +282,8 @@ export default {
             return false;
         }
 
-        for (let index in array) {
-            if ((strict && array[index] === value) || (!strict && array[index] == value)) {
+        for (let i = 0; i < array.length; i++) {
+            if ((strict && array[i] === value) || (!strict && array[i] == value)) {
                 return true;
             }
         }

--- a/tests/H.spec.js
+++ b/tests/H.spec.js
@@ -1,4 +1,5 @@
 
+import './misc';
 import H from '../src/H';
 import Handlebars from 'handlebars';
 
@@ -10,5 +11,4 @@ describe('H.registerHelpers', () => {
         spyOn(Handlebars.helpers, 'excerpt');
         spyOn(Handlebars.helpers, 'checkedIf');
     });
-
 });

--- a/tests/helpers/conditionals.spec.js
+++ b/tests/helpers/conditionals.spec.js
@@ -1,3 +1,4 @@
+import '../misc';
 import {compile} from 'handlebars';
 import conditionals from '../../src/helpers/conditionals';
 
@@ -369,7 +370,7 @@ describe('conditionals', () => {
 
             expect(template({condition1: true, condition2: false, condition3: true})).toEqual('true');
         });
-        
+
         it('should work fine with direct boolean values', () => {
             var template = compile('{{concat "The or operator: " (or false false)}}');
 

--- a/tests/helpers/datetime.spec.js
+++ b/tests/helpers/datetime.spec.js
@@ -1,3 +1,4 @@
+import '../misc';
 import {compile} from 'handlebars';
 import datetime from '../../src/helpers/datetime';
 

--- a/tests/helpers/html.spec.js
+++ b/tests/helpers/html.spec.js
@@ -1,3 +1,4 @@
+import '../misc';
 import {compile} from 'handlebars';
 import html from '../../src/helpers/html';
 

--- a/tests/helpers/math.spec.js
+++ b/tests/helpers/math.spec.js
@@ -1,3 +1,4 @@
+import '../misc';
 import {compile} from 'handlebars';
 import math from '../../src/helpers/math';
 

--- a/tests/helpers/strings.spec.js
+++ b/tests/helpers/strings.spec.js
@@ -1,3 +1,4 @@
+import '../misc';
 import {compile} from 'handlebars';
 import strings from '../../src/helpers/strings';
 

--- a/tests/misc.js
+++ b/tests/misc.js
@@ -1,0 +1,7 @@
+
+// NOTE: Just to make sure all the tests passes if the Array.prototype is modified.
+Array.prototype.someMethod = function() {
+    return 'this is just a test';
+};
+
+export {Array};


### PR DESCRIPTION
Helpers like `or`, `and`, `coalesce` were not functioning properly in case new methods are added to `Array.prototype` by the user. 

This PR does the fix. 
PS: `package.json` has been modified. 
Closes #40