### PR TITLE
Use CurrencyFormatter.js instead of currency-formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ H.registerHelpers(Handlebars);
 | [selectedIf](#selectedif)             | Select `<option>` if expression is true                 |
 | [checkedIf](#checkedif)               | Check the `<input>` checkbox if expression is true      |
 | [options](#options)                   | Generate `<option>` list for `<select>`                 |
-| [currency](#currency)                 | Format currency value according to country              |
+| [formatCurrency](#formatcurrency)     | Format currency value according to country              |
 
 ### Conditional
 #### eq
@@ -814,8 +814,8 @@ will generate HTML:
 
 ### Formatters
 
-#### currency
-Format the currency value according to country.
+#### formatCurrency
+Format the currency value according to country code and locale.
 
 Parameters:
 ```
@@ -827,12 +827,12 @@ Returns: `string`
 
 Usage:
 ```
-{{currency 1000000 code='USD'}}  => $1,000,000.00
-{{currency 1000000 code='EUR'}}  => 1 000 000,00 €
-{{currency 1000000 code='EUR' precision=0}}  => 1 000 000 €
+{{formatCurrency 1234567.89 currency='USD'}}  => $1,234,567.89
+{{formatCurrency 1234567.89 currency='EUR'}}  => 1.234.567,89 €
+{{formatCurrency 1234567.89 currency='EUR' locale="en"}}  => €1,234,567.89
 ```
 
-Note: The currency formatting parameters are used from [https://github.com/smirzaei/currency-formatter](https://github.com/smirzaei/currency-formatter).
+Note: The currency formatting parameters are used from [https://github.com/osrec/currencyFormatter.js](https://github.com/osrec/currencyFormatter.js).
 
 ## Testing the helpers
 

--- a/README.md
+++ b/README.md
@@ -827,9 +827,9 @@ Returns: `string`
 
 Usage:
 ```
-{{formatCurrency 1234567.89 currency='USD'}}  => $1,234,567.89
-{{formatCurrency 1234567.89 currency='EUR'}}  => 1.234.567,89 €
-{{formatCurrency 1234567.89 currency='EUR' locale="en"}}  => €1,234,567.89
+{{formatCurrency 1234567.89 code='USD'}}  => $1,234,567.89
+{{formatCurrency 1234567.89 code='EUR'}}  => 1.234.567,89 €
+{{formatCurrency 1234567.89 code='EUR' locale="en"}}  => €1,234,567.89
 ```
 
 Note: The currency formatting parameters are used from [https://github.com/osrec/currencyFormatter.js](https://github.com/osrec/currencyFormatter.js).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,7 @@ gulp.task('bundle', ['transpile'], function() {
     var shimifyConfig = {
         'sprintf-js': '{sprintf: window.sprintf, vsprintf: window.vsprintf}',
         'moment': 'window.moment',
-        'currency': 'window.currency'
+        'currencyFormatter': 'window.OSREC.CurrencyFormatter'
     };
 
     return browserify(config)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,8 @@ gulp.task('bundle', ['transpile'], function() {
     var shimifyConfig = {
         'sprintf-js': '{sprintf: window.sprintf, vsprintf: window.vsprintf}',
         'moment': 'window.moment',
-        'currencyFormatter': 'window.OSREC.CurrencyFormatter'
+        'currencyformatter.js': 'window.OSREC.CurrencyFormatter',
+        'handlebars': 'window.Handlebars'
     };
 
     return browserify(config)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "codecov": "^1.0.1",
     "currencyformatter.js": "^1.0.4",
     "eslint": "2.2.0",
+    "faker": "^4.1.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "browserify-istanbul": "^0.2.1",
     "browserify-shimify": "0.1.0-0",
     "codecov": "^1.0.1",
-    "currency-formatter": "^1.1.1",
+    "currencyformatter.js": "^1.0.4",
     "eslint": "2.2.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",

--- a/src/helpers/formatters.js
+++ b/src/helpers/formatters.js
@@ -5,9 +5,9 @@ export default {
     /**
      * Format the currency according to the country.
      * @example
-     *      {{currency 1000000 code='USD'}}  => $1,000,000.00
-     *      {{currency 1000000 code='EUR'}}  => 1 000 000,00 €
-     *      {{currency 1000000 code='EUR' precision=0}}  => 1 000 000 €
+     *      {{formatCurrency 1234567.89 code='USD'}}  => $1,234,567.89
+     *      {{formatCurrency 1234567.89 code='EUR'}}  => 1.234.567,89 €
+     *      {{formatCurrency 1234567.89 code='EUR' locale="en"}}  => €1,234,567.89
      *
      * @param value
      * @param args
@@ -37,6 +37,8 @@ export default {
         if (params.length) {
             params = params[0];
         }
+
+        params.currency = !isUndefined(params.code) ? params.code : params.currency;
 
         if (!isUndefined(params.currency) && !(params.currency in currencyFormatter.symbols)) {
             console.error(`Invalid currency code ${params.currency} provided for helper \`formatCurrency\`.`);

--- a/src/helpers/formatters.js
+++ b/src/helpers/formatters.js
@@ -12,11 +12,11 @@ export default {
      * @param value
      * @param args
      */
-    currency: (value, ...args) => {
-        let currencyFormatter = global.currency;
+    formatCurrency: (value, ...args) => {
+        let currencyFormatter = global.currencyFormatter;
 
         if (!currencyFormatter) {
-            currencyFormatter = require('currency-formatter');
+            currencyFormatter = require('currencyFormatter');
         }
 
         let params = [];

--- a/src/helpers/formatters.js
+++ b/src/helpers/formatters.js
@@ -1,4 +1,4 @@
-import {isObject, isUndefined} from '../util/utils';
+import {isObject, isUndefined, isNumeric} from '../util/utils';
 
 export default {
 
@@ -16,26 +16,18 @@ export default {
         let currencyFormatter = global.OSREC && global.OSREC.CurrencyFormatter;
         let handlebars = global.Handlebars;
 
-        if (isUndefined(currencyFormatter)) {
+        if (!currencyFormatter) {
             currencyFormatter = require('currencyformatter.js');
         }
 
-        if (isUndefined(handlebars)) {
+        if (!handlebars) {
             handlebars = require('handlebars');
         }
 
-        let params = [];
+        let params = {};
 
-        args.forEach(arg => {
-            if (isObject(arg) && isObject(arg.hash)) {
-                arg = arg.hash;
-            }
-
-            params.push(arg);
-        });
-
-        if (params.length) {
-            params = params[0];
+        if (isObject(args[0]) && isObject(args[0].hash)) {
+            params = args[0].hash;
         }
 
         params.currency = !isUndefined(params.code) ? params.code : params.currency;
@@ -43,6 +35,10 @@ export default {
         if (!isUndefined(params.currency) && !(params.currency in currencyFormatter.symbols)) {
             console.error(`Invalid currency code ${params.currency} provided for helper \`formatCurrency\`.`);
 
+            return;
+        }
+
+        if (!isNumeric(value)) {
             return;
         }
 

--- a/src/helpers/formatters.js
+++ b/src/helpers/formatters.js
@@ -1,4 +1,4 @@
-import {isObject} from '../util/utils';
+import {isObject, isUndefined} from '../util/utils';
 
 export default {
 
@@ -13,10 +13,15 @@ export default {
      * @param args
      */
     formatCurrency: (value, ...args) => {
-        let currencyFormatter = global.currencyFormatter;
+        let currencyFormatter = global.OSREC && global.OSREC.CurrencyFormatter;
+        let handlebars = global.Handlebars;
 
-        if (!currencyFormatter) {
-            currencyFormatter = require('currencyFormatter');
+        if (isUndefined(currencyFormatter)) {
+            currencyFormatter = require('currencyformatter.js');
+        }
+
+        if (isUndefined(handlebars)) {
+            handlebars = require('handlebars');
         }
 
         let params = [];
@@ -33,6 +38,12 @@ export default {
             params = params[0];
         }
 
-        return currencyFormatter.format(value, params);
+        if (!isUndefined(params.currency) && !(params.currency in currencyFormatter.symbols)) {
+            console.error(`Invalid currency code ${params.currency} provided for helper \`formatCurrency\`.`);
+
+            return;
+        }
+
+        return new handlebars.SafeString(currencyFormatter.format(value, params));
     }
 };

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -58,4 +58,14 @@ function isArray(thing) {
     return (Object.prototype.toString.call(thing) === '[object Array]');
 }
 
-export {isFunction, isUndefined, isDefined, isObject, isArray, isString};
+/**
+ * Check if the value is numeric.
+ *
+ * @param value
+ * @returns {boolean}
+ */
+function isNumeric(value) {
+    return !isNaN(parseFloat(value)) && isFinite(value);
+}
+
+export {isFunction, isUndefined, isDefined, isObject, isArray, isString, isNumeric};

--- a/tests/helpers/formatters.spec.js
+++ b/tests/helpers/formatters.spec.js
@@ -1,3 +1,4 @@
+import faker from 'faker';
 import {compile} from 'handlebars';
 
 describe('formatters', () => {
@@ -33,9 +34,9 @@ describe('formatters', () => {
         });
 
         it('should return negative NaN USD currency invalid value after compilation', () => {
-            let template = compile('{{formatCurrency "asd"}}');
+            let template = compile('{{formatCurrency value}}');
 
-            expect(template()).toEqual('-&#x24;NaN');
+            expect(template({value: faker.random.word()})).toEqual('-&#x24;NaN');
         });
 
         it('should return USD currency value in string after compilation', () => {
@@ -45,21 +46,21 @@ describe('formatters', () => {
         });
 
         it('should return empty value for invalid currency code only', () => {
-            let template = compile('{{formatCurrency 1234567.89 currency="ZZZ"}}');
+            let template = compile('{{formatCurrency 1234567.89 currency=code}}');
 
-            expect(template()).toEqual('');
+            expect(template({code: faker.address.countryCode()})).toEqual('');
         });
 
         it('should return USD with en locale for invalid locale only', () => {
-            let template = compile('{{formatCurrency 1234567.89 en="abc"}}');
+            let template = compile('{{formatCurrency 1234567.89 en=locale}}');
 
-            expect(template()).toEqual('&#x24;1,234,567.89');
+            expect(template({locale: faker.random.locale()})).toEqual('&#x24;1,234,567.89');
         });
 
         it('should return empty value for invalid currency code and en locale', () => {
-            let template = compile('{{formatCurrency 1234567.89 currency="ZZZ"}}');
+            let template = compile('{{formatCurrency 1234567.89 currency=code}}');
 
-            expect(template()).toEqual('');
+            expect(template({code: faker.address.countryCode()})).toEqual('');
         });
     });
 });

--- a/tests/helpers/formatters.spec.js
+++ b/tests/helpers/formatters.spec.js
@@ -27,16 +27,16 @@ describe('formatters', () => {
             expect(template()).toEqual('&#x24;1,234,567.89');
         });
 
-        it('should return negative NaN USD currency no value after compilation', () => {
+        it('should return an empty string for no value after compilation', () => {
             let template = compile('{{formatCurrency}}');
 
-            expect(template()).toEqual('-&#x24;NaN');
+            expect(template()).toEqual('');
         });
 
-        it('should return negative NaN USD currency invalid value after compilation', () => {
+        it('should return an empty string for invalid value after compilation', () => {
             let template = compile('{{formatCurrency value}}');
 
-            expect(template({value: faker.random.word()})).toEqual('-&#x24;NaN');
+            expect(template({value: faker.random.word()})).toEqual('');
         });
 
         it('should return USD currency value in string after compilation', () => {
@@ -53,6 +53,12 @@ describe('formatters', () => {
 
         it('should return USD with en locale for invalid locale only', () => {
             let template = compile('{{formatCurrency 1234567.89 en=locale}}');
+
+            expect(template({locale: faker.random.locale()})).toEqual('&#x24;1,234,567.89');
+        });
+
+        it('should return USD with en locale for USD currency code and invalid locale', () => {
+            let template = compile('{{formatCurrency 1234567.89 code="USD" en=locale}}');
 
             expect(template({locale: faker.random.locale()})).toEqual('&#x24;1,234,567.89');
         });

--- a/tests/helpers/formatters.spec.js
+++ b/tests/helpers/formatters.spec.js
@@ -1,78 +1,47 @@
 import {compile} from 'handlebars';
 
 describe('formatters', () => {
-
-    describe('currency', () => {
+    describe('formatCurrency', () => {
         it('should return USD currency for USD code after compilation', () => {
-            let template = compile('{{currency 1000000 code="USD"}}');
+            let template = compile('{{formatCurrency 1234567.89 currency="USD"}}');
 
-            expect(template()).toEqual('$1,000,000.00');
+            expect(template()).toEqual('&amp;#x24;1,234,567.89');
         });
 
-        it('should return USD currency with zero precision for USD code and zero precision after compilation', () => {
-            let template = compile('{{currency 1000000.125 code="USD" precision=0}}');
+        it('should return EUR currency for EUR code after compilation', () => {
+            let template = compile('{{formatCurrency 1234567.89 currency="EUR"}}');
 
-            expect(template()).toEqual('$1,000,000');
+            expect(template()).toEqual('1.234.567,89 &amp;#x20ac;');
         });
 
-        it('should return USD currency with precision = 2 for currency with decimal values after compilation', () => {
-            let template = compile('{{currency 1000000.435 code="USD"}}');
+        it('should return EUR currency with en locale for EUR code and en locale after compilation', () => {
+            let template = compile('{{formatCurrency 1234567.89 currency="EUR" locale="en"}}');
 
-            expect(template()).toEqual('$1,000,000.44');
+            expect(template()).toEqual('&amp;#x20ac;1,234,567.89');
         });
 
-        it('should return value in thousands format for no country code after compilation', () => {
-            let template = compile('{{currency 1000000}}');
+        it('should return USD currency with no currency code after compilation', () => {
+            let template = compile('{{formatCurrency 1234567.89}}');
 
-            expect(template()).toEqual('1,000,000.00');
+            expect(template()).toEqual('&amp;#x24;1,234,567.89');
         });
 
-        it('should return value in thousands format for invalid country code after compilation', () => {
-            let template = compile('{{currency 1000000 code="ZZZ"}}');
+        it('should return negative NaN USD currency no value after compilation', () => {
+            let template = compile('{{formatCurrency}}');
 
-            expect(template()).toEqual('1,000,000.00');
+            expect(template()).toEqual('-&amp;#x24;NaN');
         });
 
-        it('should return 0.00 for invalid currency value without country code after compilation', () => {
-            let template = compile('{{currency "asd"}}');
+        it('should return negative NaN USD currency invalid value after compilation', () => {
+            let template = compile('{{formatCurrency "asd"}}');
 
-            expect(template()).toEqual('0.00');
+            expect(template()).toEqual('-&amp;#x24;NaN');
         });
 
-        it('should return USD 0.00 for invalid currency value with USD code after compilation', () => {
-            let template = compile('{{currency "asdf" code="USD"}}');
+        it('should return USD currency value in string after compilation', () => {
+            let template = compile('{{formatCurrency "1234567"}}');
 
-            expect(template()).toEqual('$0.00');
-        });
-
-        it('should return 0.00 for invalid currency value with invalid country code after compilation', () => {
-            let template = compile('{{currency "asd" code="ZZZ"}}');
-
-            expect(template()).toEqual('0.00');
-        });
-
-        it('should return 0.00 for no currency value after compilation', () => {
-            let template = compile('{{currency}}');
-
-            expect(template()).toEqual('0.00');
-        });
-
-        it('should return EUR currency value for EUR code after compilation', () => {
-            let template = compile('{{currency 1000000 code="EUR"}}');
-
-            expect(template()).toEqual('1 000 000,00 €');
-        });
-
-        it('should return EUR currency value with symbol on left for EUR code after compilation', () => {
-            let template = compile('{{currency 1000000 code="EUR" format="%s %v"}}');
-
-            expect(template()).toEqual('€ 1 000 000,00');
-        });
-
-        it('should return EUR currency value with "," as thousand separator and "." as decimal separator for EUR code after compilation', () => {
-            let template = compile('{{currency 1000000.25 code="EUR" thousand="," decimal="."}}');
-
-            expect(template()).toEqual('1,000,000.25 €');
+            expect(template()).toEqual('&amp;#x24;1,234,567.00');
         });
     });
 });

--- a/tests/helpers/formatters.spec.js
+++ b/tests/helpers/formatters.spec.js
@@ -5,43 +5,61 @@ describe('formatters', () => {
         it('should return USD currency for USD code after compilation', () => {
             let template = compile('{{formatCurrency 1234567.89 currency="USD"}}');
 
-            expect(template()).toEqual('&amp;#x24;1,234,567.89');
+            expect(template()).toEqual('&#x24;1,234,567.89');
         });
 
         it('should return EUR currency for EUR code after compilation', () => {
             let template = compile('{{formatCurrency 1234567.89 currency="EUR"}}');
 
-            expect(template()).toEqual('1.234.567,89 &amp;#x20ac;');
+            expect(template()).toEqual('1.234.567,89 &#x20ac;');
         });
 
         it('should return EUR currency with en locale for EUR code and en locale after compilation', () => {
             let template = compile('{{formatCurrency 1234567.89 currency="EUR" locale="en"}}');
 
-            expect(template()).toEqual('&amp;#x20ac;1,234,567.89');
+            expect(template()).toEqual('&#x20ac;1,234,567.89');
         });
 
         it('should return USD currency with no currency code after compilation', () => {
             let template = compile('{{formatCurrency 1234567.89}}');
 
-            expect(template()).toEqual('&amp;#x24;1,234,567.89');
+            expect(template()).toEqual('&#x24;1,234,567.89');
         });
 
         it('should return negative NaN USD currency no value after compilation', () => {
             let template = compile('{{formatCurrency}}');
 
-            expect(template()).toEqual('-&amp;#x24;NaN');
+            expect(template()).toEqual('-&#x24;NaN');
         });
 
         it('should return negative NaN USD currency invalid value after compilation', () => {
             let template = compile('{{formatCurrency "asd"}}');
 
-            expect(template()).toEqual('-&amp;#x24;NaN');
+            expect(template()).toEqual('-&#x24;NaN');
         });
 
         it('should return USD currency value in string after compilation', () => {
             let template = compile('{{formatCurrency "1234567"}}');
 
-            expect(template()).toEqual('&amp;#x24;1,234,567.00');
+            expect(template()).toEqual('&#x24;1,234,567.00');
+        });
+
+        it('should return empty value for invalid currency code only', () => {
+            let template = compile('{{formatCurrency 1234567.89 currency="ZZZ"}}');
+
+            expect(template()).toEqual('');
+        });
+
+        it('should return USD with en locale for invalid locale only', () => {
+            let template = compile('{{formatCurrency 1234567.89 en="abc"}}');
+
+            expect(template()).toEqual('&#x24;1,234,567.89');
+        });
+
+        it('should return empty value for invalid currency code and en locale', () => {
+            let template = compile('{{formatCurrency 1234567.89 currency="ZZZ"}}');
+
+            expect(template()).toEqual('');
         });
     });
 });

--- a/tests/helpers/formatters.spec.js
+++ b/tests/helpers/formatters.spec.js
@@ -4,19 +4,19 @@ import {compile} from 'handlebars';
 describe('formatters', () => {
     describe('formatCurrency', () => {
         it('should return USD currency for USD code after compilation', () => {
-            let template = compile('{{formatCurrency 1234567.89 currency="USD"}}');
+            let template = compile('{{formatCurrency 1234567.89 code="USD"}}');
 
             expect(template()).toEqual('&#x24;1,234,567.89');
         });
 
         it('should return EUR currency for EUR code after compilation', () => {
-            let template = compile('{{formatCurrency 1234567.89 currency="EUR"}}');
+            let template = compile('{{formatCurrency 1234567.89 code="EUR"}}');
 
             expect(template()).toEqual('1.234.567,89 &#x20ac;');
         });
 
         it('should return EUR currency with en locale for EUR code and en locale after compilation', () => {
-            let template = compile('{{formatCurrency 1234567.89 currency="EUR" locale="en"}}');
+            let template = compile('{{formatCurrency 1234567.89 code="EUR" locale="en"}}');
 
             expect(template()).toEqual('&#x20ac;1,234,567.89');
         });
@@ -46,9 +46,9 @@ describe('formatters', () => {
         });
 
         it('should return empty value for invalid currency code only', () => {
-            let template = compile('{{formatCurrency 1234567.89 currency=code}}');
+            let template = compile('{{formatCurrency 1234567.89 code=countryCode}}');
 
-            expect(template({code: faker.address.countryCode()})).toEqual('');
+            expect(template({countryCode: faker.address.countryCode()})).toEqual('');
         });
 
         it('should return USD with en locale for invalid locale only', () => {
@@ -58,9 +58,9 @@ describe('formatters', () => {
         });
 
         it('should return empty value for invalid currency code and en locale', () => {
-            let template = compile('{{formatCurrency 1234567.89 currency=code}}');
+            let template = compile('{{formatCurrency 1234567.89 code=countryCode}}');
 
-            expect(template({code: faker.address.countryCode()})).toEqual('');
+            expect(template({countryCode: faker.address.countryCode()})).toEqual('');
         });
     });
 });

--- a/tests/util/utils.spec.js
+++ b/tests/util/utils.spec.js
@@ -56,4 +56,50 @@ describe('utils', () => {
             expect(utils.isArray(567)).toEqual(false);
         });
     });
+
+    describe('isNumeric', () => {
+        it('should return false if param passed is null', () => {
+            expect(utils.isNumeric(null)).toEqual(false);
+        });
+
+        it('should return false if param passed is undefined', () => {
+            expect(utils.isNumeric(undefined)).toEqual(false);
+        });
+
+        it('should return false if param passed is an empty string', () => {
+            expect(utils.isNumeric('')).toEqual(false);
+        });
+
+        it('should return false if param passed is invalid numerical string', () => {
+            expect(utils.isNumeric('a34')).toEqual(false);
+        });
+
+        it('should return false if param passed is a boolean false', () => {
+            expect(utils.isNumeric(false)).toEqual(false);
+        });
+
+        it('should return false if param passed is a boolean true', () => {
+            expect(utils.isNumeric(true)).toEqual(false);
+        });
+
+        it('should return true if param passed is a valid integer', () => {
+            expect(utils.isNumeric(123)).toEqual(true);
+        });
+
+        it('should return true if param passed is a valid integer as a string', () => {
+            expect(utils.isNumeric('123')).toEqual(true);
+        });
+
+        it('should return true if param passed is a valid negative integer', () => {
+            expect(utils.isNumeric(-123)).toEqual(true);
+        });
+
+        it('should return true if param passed is a valid negative integer as a string', () => {
+            expect(utils.isNumeric('-123')).toEqual(true);
+        });
+
+        it('should return true if param passed is a valid real number', () => {
+            expect(utils.isNumeric(123.56)).toEqual(true);
+        });
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,6 @@ accepts@1.3.3:
     mime-types "~2.1.11"
     negotiator "0.6.1"
 
-accounting@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/accounting/-/accounting-0.4.1.tgz#87dd4103eff7f4460f1e186f5c677ed6cf566883"
-
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -1279,13 +1275,9 @@ crypto-browserify@^3.0.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
 
-currency-formatter@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/currency-formatter/-/currency-formatter-1.2.0.tgz#18a9dd3f20935b0e54b4c455a269d4811331579e"
-  dependencies:
-    accounting "^0.4.1"
-    locale-currency "0.0.1"
-    object-assign "^4.1.1"
+currencyformatter.js@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/currencyformatter.js/-/currencyformatter.js-1.0.4.tgz#0e16be1701fcfd282def63e33cbaf1373d72fec6"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -1873,6 +1865,10 @@ extract-zip@~1.5.0:
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+
+faker@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
 
 falafel@^2.0.0:
   version "2.1.0"
@@ -3065,10 +3061,6 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-locale-currency@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/locale-currency/-/locale-currency-0.0.1.tgz#c9e15a22ff575b4b4bb947a4bf92ac236bd1fe9b"
-
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
@@ -3473,7 +3465,7 @@ object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
-object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 


### PR DESCRIPTION
- Replace library [currency-formatter](https://github.com/smirzaei/currency-formatter) by [CurrencyFormatter.js](https://github.com/osrec/currencyFormatter.js)
- Update README
- Change helper `currency` to `formatCurrency`
- Update test cases
- Add `isNumeric` utility function with test cases

Test cases for `formatCurrency`:
```bash
formatters
    formatCurrency
      ✓ should return USD currency for USD code after compilation
      ✓ should return EUR currency for EUR code after compilation
      ✓ should return EUR currency with en locale for EUR code and en locale after compilation
      ✓ should return USD currency with no currency code after compilation
      ✓ should return negative NaN USD currency no value after compilation
      ✓ should return negative NaN USD currency invalid value after compilation
      ✓ should return USD currency value in string after compilation
      ✓ should return empty value for invalid currency code only
      ✓ should return USD with en locale for invalid locale only
      ✓ should return an empty string for invalid value after compilation
      ✓ should return empty value for invalid currency code and en locale
```

Test cases for `isNumeric`:
```bash
isNumeric
      ✓ should return false if param passed is null
      ✓ should return false if param passed is undefined
      ✓ should return false if param passed is an empty string
      ✓ should return false if param passed is invalid numerical string
      ✓ should return false if param passed is a boolean false
      ✓ should return false if param passed is a boolean true
      ✓ should return true if param passed is a valid integer
      ✓ should return true if param passed is a valid integer as a string
      ✓ should return true if param passed is a valid negative integer
      ✓ should return true if param passed is a valid negative integer as a string
      ✓ should return true if param passed is a valid real number
```