### PR TITLE
Add change log generation and release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "codecov": "cat coverage/*/lcov.info | codecov",
     "start": "karma start",
     "clean": "rimraf dist/ lib/",
-    "build": "yarn clean && gulp"
+    "build": "yarn clean && gulp",
+    "bump": "./release.sh bump",
+    "changelog": "./release.sh changelog"
   }
 }

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Release management and changelog generation script.
+
+set -e
+
+changelog() {
+  # NOTE: This requires github_changelog_generator to be installed.
+  # https://github.com/skywinder/github-changelog-generator
+
+  if [ -z "$NEXT" ]; then
+      NEXT="Unreleased"
+  fi
+
+  echo "Generating changelog upto version: $NEXT"
+  github_changelog_generator \
+    --no-verbose \
+    --pr-label "**Changes**" \
+    --bugs-label "**Bug Fixes**" \
+    --issues-label "**Closed Issues**" \
+    --issue-line-labels=ALL \
+    --future-release="$NEXT" \
+    --release-branch=master \
+    --exclude-labels=unnecessary,duplicate,question,invalid,wontfix
+}
+
+bump() {
+  # Bump package version and generate changelog
+  VERSION="${NEXT/v/}"
+
+  echo "Bump version to ${VERSION}"
+
+  # Update version in the following files
+  sed -i "s/\(\"version\":\s*\"\)[^\"]*\(\"\)/\1${VERSION}\2/g" package.json
+
+  # Generate change log
+  changelog
+  echo ""
+
+  # Generate new build.
+  yarn && yarn test && yarn build
+
+  # Prepare to commit
+  git add CHANGELOG.md package.json yarn.lock && \
+    git commit -v --edit -m "${VERSION} Release :tada: :fireworks: :bell:" && \
+    git tag "$NEXT" && \
+    echo -e "\nRelease tagged $NEXT"
+  git push origin HEAD --tags
+  yarn publish --new-version "${VERSION}" --no-git-tag-version
+}
+
+# Run command received from args.
+$1


### PR DESCRIPTION
Add change log generation and release script.

**Generate change log**
Generates change log and updates `CHANGELOG.md` file.
```bash
$ yarn changelog
```

**Bump and publish**
Updates `package.json`, generates change log, runs tests, generates build, commits, creates a tag and publishes the package to npm registry.
```bash
$ NEXT=v1.0.16 yarn bump
```
