### PR TITLE
adjust excerpt function to make suffix a keyword argument

### DIFF
--- a/src/helpers/strings.js
+++ b/src/helpers/strings.js
@@ -1,4 +1,4 @@
-import { isFunction, isObject, isString, isArray } from '../util/utils';
+import { isFunction, isObject, isString, isArray, isUndefined } from '../util/utils';
 
 /**
  * Extract a few characters from a string. Default number of characters is 50.
@@ -8,11 +8,17 @@ import { isFunction, isObject, isString, isArray } from '../util/utils';
  *
  * @param {string} string
  * @param {int} length
+ * @param {any} args
  * @returns {string}
  */
-export function excerpt(string, length, suffix) {
+export function excerpt(string, length, ...args) {
   length = parseInt(length) || 50;
-  suffix = isString(suffix) ? suffix : '...';
+  
+  let params = {};
+  if (isObject(args[0]) && isObject(args[0].hash)) {
+    params = args[0].hash;
+  }
+  let suffix = !isUndefined(params.suffix) ? params.suffix : '...';
 
   if (typeof (string) !== 'string' || typeof (length) !== 'number') {
     return string;

--- a/src/helpers/strings.js
+++ b/src/helpers/strings.js
@@ -10,8 +10,9 @@ import { isFunction, isObject, isString, isArray } from '../util/utils';
  * @param {int} length
  * @returns {string}
  */
-export function excerpt(string, length) {
+export function excerpt(string, length, suffix) {
   length = parseInt(length) || 50;
+  suffix = isString(suffix) ? suffix : '...';
 
   if (typeof (string) !== 'string' || typeof (length) !== 'number') {
     return string;
@@ -21,7 +22,7 @@ export function excerpt(string, length) {
     return string;
   }
 
-  return string.slice(0, length) + '...';
+  return string.slice(0, length) + suffix;
 }
 
 /**

--- a/tests/helpers/strings.spec.js
+++ b/tests/helpers/strings.spec.js
@@ -18,14 +18,6 @@ describe('strings', () => {
       expect(strings.excerpt('Just wow', 4)).toEqual('Just...');
     });
 
-    it('should use user-provided suffix instead of the default, if specified', () => {
-      expect(strings.excerpt('Just wow', 4, '')).toEqual('Just');
-    });
-
-    it('should use non-empty user-provided suffix instead of the default, if specified', () => {
-      expect(strings.excerpt('Just wow', 4, ' mysuffix')).toEqual('Just mysuffix');
-    });
-
     it('should extract all the characters from a string if the provided number of characters to be extracted is more than the number of characters', () => {
       expect(strings.excerpt('wow', 10)).toEqual('wow');
     });
@@ -45,10 +37,18 @@ describe('strings', () => {
     });
 
     it('should work as expected after compilation with user-provided suffix', () => {
-      const template = compile('{{excerpt string 10 ""}}');
+      const template = compile('{{excerpt string 10 suffix=""}}');
 
       expect(template({ string: 'That can only mean one thing' })).toEqual('That can o');
     });
+
+    it('should work as expected after compilation with user-provided suffix', () => {
+      const template = compile('{{excerpt string 10 suffix="asdf"}}');
+
+      expect(template({ string: 'That can only mean one thing' })).toEqual('That can oasdf');
+    });
+
+    
   });
 
   describe('sanitize', () => {

--- a/tests/helpers/strings.spec.js
+++ b/tests/helpers/strings.spec.js
@@ -18,6 +18,14 @@ describe('strings', () => {
       expect(strings.excerpt('Just wow', 4)).toEqual('Just...');
     });
 
+    it('should use user-provided suffix instead of the default, if specified', () => {
+      expect(strings.excerpt('Just wow', 4, '')).toEqual('Just');
+    });
+
+    it('should use non-empty user-provided suffix instead of the default, if specified', () => {
+      expect(strings.excerpt('Just wow', 4, ' mysuffix')).toEqual('Just mysuffix');
+    });
+
     it('should extract all the characters from a string if the provided number of characters to be extracted is more than the number of characters', () => {
       expect(strings.excerpt('wow', 10)).toEqual('wow');
     });
@@ -34,6 +42,12 @@ describe('strings', () => {
       const template = compile('{{excerpt string 10}}');
 
       expect(template({ string: 'That can only mean one thing' })).toEqual('That can o...');
+    });
+
+    it('should work as expected after compilation with user-provided suffix', () => {
+      const template = compile('{{excerpt string 10 ""}}');
+
+      expect(template({ string: 'That can only mean one thing' })).toEqual('That can o');
     });
   });
 


### PR DESCRIPTION
This PR would extend the existing `excerpt` function to take an optional keyword argument `suffix=` that would be appended to the end of the excerpt, instead of the current `...` ellipsis. If the argument is unspecified, the `...` suffix will be retained, i.e. this change is backwards compatible. 

For instance, if `suffix` is set to an empty string, the excerpt will be just the first N characters of the string. ``{{excerpt string 10 suffix=""}}` returns `'That can o'` and `{{excerpt string 10 suffix="asdf"}}` returns `'That can oasdf'`.

I have added tests; all pre-existing tests pass unmodified.

For context: just-handlebars-helpers is packaged with Apache Superset's handlebars charts. I need to do some string processing there and want to use excerpt without the ellipsis. 